### PR TITLE
Add null checks to getExternalFilesDir calls

### DIFF
--- a/android/src/main/java/com/ReactNativeBloBUtil/Utils/PathResolver.java
+++ b/android/src/main/java/com/ReactNativeBloBUtil/Utils/PathResolver.java
@@ -29,7 +29,9 @@ public class PathResolver {
                 final String type = split[0];
 
                 if ("primary".equalsIgnoreCase(type)) {
-                    return context.getExternalFilesDir(null) + "/" + split[1];
+                    File dir = context.getExternalFilesDir(null);
+                    if (dir != null) return dir + "/" + split[1];
+                    return "";
                 }
 
                 // TODO handle non-primary volumes


### PR DESCRIPTION
Both [getExternalStorageDirectory](https://developer.android.com/reference/android/os/Environment#getExternalStorageDirectory()) and [getExternalStoragePublicDirectory](https://developer.android.com/reference/android/os/Environment#getExternalStoragePublicDirectory(java.lang.String)) are deprecated in API 29, so they were changed to [Context.getExternalFilesDir](https://developer.android.com/reference/android/content/Context#getExternalFilesDir(java.lang.String)) on a previous commit.
As mentioned in the documentation, Context.getExternalFilesDir() may return null, so a check before chaining calls is needed.

This PR adds such null checks or wraps the call in a try-catch sentence in case of a Promise related call.

Closes #29 
