### PR TITLE
check write results to handle failures

### DIFF
--- a/ios/ReactNativeBlobUtilFS.m
+++ b/ios/ReactNativeBlobUtilFS.m
@@ -396,7 +396,10 @@ NSMutableDictionary *fileStreams = nil;
             [fileHandle closeFile];
         }
         else {
-            [content writeToFile:path atomically:YES];
+            if (![content writeToFile:path atomically:YES]) {
+                fm = nil;
+                return reject(@"EUNSPECIFIED", [NSString stringWithFormat:@"File '%@' could not be written.", path], nil);
+            }
         }
         fm = nil;
 
@@ -460,7 +463,11 @@ NSMutableDictionary *fileStreams = nil;
                 [fileHandle closeFile];
             }
             else {
-                [fileContent writeToFile:path atomically:YES];
+                if (![fileContent writeToFile:path atomically:YES]) {
+                    free(bytes);
+                    fm = nil;
+                    return reject(@"EUNSPECIFIED", [NSString stringWithFormat:@"File '%@' could not be written.", path], nil);
+                }
             }
         }
         free(bytes);


### PR DESCRIPTION
As documented in https://developer.apple.com/documentation/foundation/nsdata/1408033-writetofile, `writeToFile` may return NO if it failed for some reason (e.g., invalid path or not enough space).

Right now, the code is not handling this scenario and the file is reported back as written, even if it fails.

This PR adds a check to make sure the file is properly written.


PS: It would be great for this package to stop being a fork since I end up in the old package every time I want to do a PR!

@RonRadtke We have been seeing some data loss very rarely, but this is most likely the cause we have found. Please review and merge asap!