### PR TITLE
Fixed MalformedInputException on Android when reading utf8 JSONStream.

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
@@ -24,6 +24,7 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -365,6 +366,7 @@ class ReactNativeBlobUtilFS {
 
             if (encoding.equalsIgnoreCase("utf8")) {
                 CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
+                encoder.onMalformedInput(CodingErrorAction.IGNORE);
                 while ((cursor = fs.read(buffer)) != -1) {
                     encoder.encode(ByteBuffer.wrap(buffer).asCharBuffer());
                     String chunk = new String(buffer, 0, cursor);

--- a/polyfill/XMLHttpRequest.js
+++ b/polyfill/XMLHttpRequest.js
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import {NativeModules} from 'react-native';
+import ReactNativeBlobUtil from '../index.js';
 import XMLHttpRequestEventTarget from './XMLHttpRequestEventTarget.js'
 import Log from '../utils/log.js'
 import Blob from './Blob.js'
 import ProgressEvent from './ProgressEvent.js'
 import URIUtil from '../utils/uri'
 
-const ReactNativeBlobUtil = NativeModules.ReactNativeBlobUtil
 const log = new Log('XMLHttpRequest')
 
 log.disable()


### PR DESCRIPTION
On Android malformed input exception was throwing while reading a json file using JSONStream because this coding error was not handled. Code updated with CodingErrorAction.IGNORE.
 
And when using the XMLHttpRequest polyfill for JSONStream console was showing the error
` undefined is not a function (near '...ReactNativeBlobUtil.config...')`. It is fixed by updating the import statement in `polyfill/XMLHttpRequest.js`.