### PR TITLE
fetch.js - call fs.session() instead of session().

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -259,7 +259,7 @@ export function fetch(...args: any): Promise {
                 if (options.path || options.fileCache || options.addAndroidDownloads
                     || options.key || options.auto && respInfo.respType === 'blob') {
                     if (options.session)
-                        session(options.session).add(data);
+                        fs.session(options.session).add(data);
                 }
                 respInfo.rnfbEncode = rawType;
                 resolve(new FetchBlobResponse(taskId, respInfo, data));


### PR DESCRIPTION
fetch.js - call fs.session() instead of session(). Fixes ReferenceError session is not defined.