### PR TITLE
fixes FS.df callback return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -392,8 +392,22 @@ export interface FS {
 
     slice(src: string, dest: string, start: number, end: number): Promise<void>;
     asset(path: string): string;
-    df(): Promise<{ free: number, total: number }>;
+    df(): Promise<RNFetchBlobDf>;
 }
+
+export interface RNFetchBlobDfIOS {
+    free?: number;
+    total?: number;
+}
+
+export interface RNFetchBlobDfAndroid {
+    external_free?: string;
+    external_total?: string;
+    internal_free?: string;
+    internal_total?: string;
+}
+
+export type RNFetchBlobDf = RNFetchBlobDfIOS & RNFetchBlobDfAndroid;
 
 export interface Dirs {
     DocumentDir: string;


### PR DESCRIPTION
As per https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56758.
Source: 
- Android: https://github.com/RonRadtke/react-native-blob-util/blob/06f8c707e56331e587da0b4b65aebac9411265d0/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java#L1032
- iOS: https://github.com/RonRadtke/react-native-blob-util/blob/06f8c707e56331e587da0b4b65aebac9411265d0/ios/ReactNativeBlobUtilFS.m#L919

I suggest merging this PR once the one on DefinitelyTyped gets approved and merged 