### PR TITLE
android: only do gradle afterEvaluate when building this lib alone

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,6 +62,11 @@ dependencies {
 }
 
 afterEvaluate { project ->
+    // do this only when building this lib alone as a root project
+    if (project != rootProject) {
+        return
+    }
+
     // some Gradle build hooks ref:
     // https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html
     task androidJavadoc(type: Javadoc) {


### PR DESCRIPTION
## Motivation

The `afterEvaluate` section in `build.gradle` breaks the RN building from source. ( I'm testing RN 0.67 )
Throws:

```
* What went wrong:
A problem occurred configuring project ':react-native-blob-util'.
> Could not resolve all files for configuration ':react-native-blob-util:debugCompileClasspath'.
   > Could not resolve com.facebook.react:react-native:+.
     Required by:
         project :react-native-blob-util
      > No matching configuration of project :ReactAndroid was found. The consumer was configured to find an API of a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'debug' but:
          - None of the consumable configurations have attributes.

```

Seems the `afterEvaluate` in `build.gradle` is only needed when build/publish this lib alone, this PR add a check to ignore the process when building the RN app (via early return) to prevent unnecessary polluting variable and cause main RN app build failed.

## Test Plan

* This lib's `./gradlew build` and `./gradlew publish` should work like in #68
* RN App should build successfully


maybe related: #72