### PR TITLE
Fix normalizing file:// paths with special characters

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
@@ -1185,9 +1185,6 @@ class ReactNativeBlobUtilFS {
             return null;
         if (!path.matches("\\w+\\:.*"))
             return path;
-        if (path.startsWith("file://")) {
-            return path.replace("file://", "");
-        }
 
         Uri uri = Uri.parse(path);
         if (path.startsWith(ReactNativeBlobUtilConst.FILE_PREFIX_BUNDLE_ASSET)) {


### PR DESCRIPTION
Resubmitting https://github.com/joltup/rn-fetch-blob/pull/736

File uris with space and other special characters are not correctly normalized. The fix is to removing 3 lines of code on `normalizePath()` because the correct normalization code already exists in `PathResolver.getRealPathFromURI()`.

Example input: `file:///storage/emulated/0/Foo%20Bar`
Correct output: `/storage/emulated/0/Foo Bar`.
Current (wrong) output: `/storage/emulated/0/Foo%20Bar`.

PS: Is it possible for you to take a look at other PRs in https://github.com/joltup/rn-fetch-blob/pull/736 as well? I know that's a lot to ask, so I get it if you say no :)
