### PR TITLE
fix upload file failed with url prefix "file://"

### DIFF
--- a/ios/ReactNativeBlobUtilReqBuilder.m
+++ b/ios/ReactNativeBlobUtilReqBuilder.m
@@ -115,6 +115,7 @@
                 if([body hasPrefix:FILE_PREFIX]) {
                     __block NSString * orgPath = [body substringFromIndex:[FILE_PREFIX length]];
                     orgPath = [ReactNativeBlobUtilFS getPathOfAsset:orgPath];
+                    orgPath = [[NSURL URLWithString:orgPath] path];
                     if([orgPath hasPrefix:AL_PREFIX])
                     {
                         


### PR DESCRIPTION
Fix ios/RNFetchBlobReqBuilder.m - buildOctetRequest method upload file failed with url prefix "file://".