### PR TITLE
Fix for Dotless i Problem on Android

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
@@ -311,8 +311,9 @@ public class ReactNativeBlobUtilReq extends BroadcastReceiver implements Runnabl
                         else if (value.equalsIgnoreCase("utf8"))
                             responseFormat = ResponseFormat.UTF8;
                     } else {
-                        builder.header(key.toLowerCase(), value);
-                        mheaders.put(key.toLowerCase(), value);
+                        temp_key=key.replace("I","i").toLowerCase(); //to prevent dotless i problem on android with turkish locale (https://github.com/joltup/rn-fetch-blob/pull/762)
+                        builder.header(temp_key, value);
+                        mheaders.put(temp_key, value);
                     }
                 }
             }


### PR DESCRIPTION
.toLowerCase() function on an Android system with Turkish language causes a bug.

Please see: https://github.com/joltup/rn-fetch-blob/issues/573

Error message starts with "Error RNFetchBlob request error: Unexpected char 0x131 at ...". -> 0x131 is ı (dotless i).

.toLowerCase() function works and does its job in a correct way. However, dotless i and normal i aren't considered equal, naturally.

Only workaround, as far as i can find out, is this.