### PR TITLE
Fix "envionment" typo

### DIFF
--- a/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.m
+++ b/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.m
@@ -535,7 +535,7 @@ RCT_EXPORT_METHOD(readStream:(NSString *)path withEncoding:(NSString *)encoding 
     });
 }
 
-#pragma mark - fs.getEnvionmentDirs
+#pragma mark - fs.getEnvironmentDirs
 RCT_EXPORT_METHOD(getEnvironmentDirs:(RCTResponseSenderBlock) callback)
 {
 


### PR DESCRIPTION
Simple typo fix for `envionment` to `environment`