### PR TITLE
Fix content length to be capped at Integer.MAX_VALUE for downloads

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/Response/ReactNativeBlobUtilFileResp.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/Response/ReactNativeBlobUtilFileResp.java
@@ -72,6 +72,10 @@ public class ReactNativeBlobUtilFileResp extends ResponseBody {
 
     @Override
     public long contentLength() {
+        if (originalBody.contentLength() > Integer.MAX_VALUE) {
+            // This is a workaround for a bug Okio buffer where it can't handle larger than int.
+            return Integer.MAX_VALUE;
+        }
         return originalBody.contentLength();
     }
 


### PR DESCRIPTION
This fixes a progress reporting problem for Android only on files > 2.14 GB. This is not a super clean fix but it does help with my very specific use case :) 