### PR TITLE
fix: 🐛 fs.xxx normalizePath

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
@@ -442,6 +442,7 @@ class ReactNativeBlobUtilFS {
      * @param promise JS promise
      */
     static void mkdir(String path, Promise promise) {
+        path = ReactNativeBlobUtilUtils.normalizePath(path);
         File dest = new File(path);
         if (dest.exists()) {
             promise.reject("EEXIST", (dest.isDirectory() ? "Folder" : "File") + " '" + path + "' already exists");
@@ -469,6 +470,7 @@ class ReactNativeBlobUtilFS {
      */
     static void cp(String path, String dest, Callback callback) {
         path = ReactNativeBlobUtilUtils.normalizePath(path);
+        dest = ReactNativeBlobUtilUtils.normalizePath(dest);
         InputStream in = null;
         OutputStream out = null;
         String message = "";
@@ -525,6 +527,8 @@ class ReactNativeBlobUtilFS {
      * @param callback JS context callback
      */
     static void mv(String path, String dest, Callback callback) {
+        path = ReactNativeBlobUtilUtils.normalizePath(path);
+        dest = ReactNativeBlobUtilUtils.normalizePath(dest);
         File src = new File(path);
         if (!src.exists()) {
             callback.invoke("Source file at path `" + path + "` does not exist");
@@ -628,6 +632,7 @@ class ReactNativeBlobUtilFS {
     static void slice(String path, String dest, int start, int end, String encode, Promise promise) {
         try {
             path = ReactNativeBlobUtilUtils.normalizePath(path);
+            dest = ReactNativeBlobUtilUtils.normalizePath(dest);
             File source = new File(path);
             if (source.isDirectory()) {
                 promise.reject("EISDIR", "Expecting a file but '" + path + "' is a directory");
@@ -883,6 +888,7 @@ class ReactNativeBlobUtilFS {
      */
     static void createFileASCII(String path, ReadableArray data, Promise promise) {
         try {
+            path = ReactNativeBlobUtilUtils.normalizePath(path);
             File dest = new File(path);
             boolean created = dest.createNewFile();
             if (!created) {

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
@@ -839,6 +839,7 @@ class ReactNativeBlobUtilFS {
      */
     static void createFile(String path, String data, String encoding, Promise promise) {
         try {
+            path = ReactNativeBlobUtilUtils.normalizePath(path);
             File dest = new File(path);
             boolean created = dest.createNewFile();
             if (encoding.equals(ReactNativeBlobUtilConst.DATA_ENCODE_URI)) {

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
@@ -790,6 +790,8 @@ class ReactNativeBlobUtilFS {
                 promise.reject("EINVAL", "Invalid algorithm '" + algorithm + "', must be one of md5, sha1, sha224, sha256, sha384, sha512");
                 return;
             }
+            
+            path = ReactNativeBlobUtilUtils.normalizePath(path);
 
             File file = new File(path);
 

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
@@ -54,6 +54,7 @@ class ReactNativeBlobUtilFS {
     static boolean writeFile(String path, String encoding, String data, final boolean append) {
         try {
             int written;
+            path = ReactNativeBlobUtilUtils.normalizePath(path);
             File f = new File(path);
             File dir = f.getParentFile();
             if (!f.exists()) {


### PR DESCRIPTION
for example

```js
import { launchImageLibrary } from "react-native-image-picker";
import ReactNativeBlobUtil from "react-native-blob-util";

launchImageLibrary({
  mediaType: "mixed",
  quality: 0.6,
})
  .then((d) => d.assets)
  .then((files) => {
    console.log("文件路径：", files[0].uri);
    return ReactNativeBlobUtil.fs.hash(files[0].uri, "sha256");
  })
  .then((fileHash) => {
    console.log("hash sha256");
    console.log(fileHash);
  })
  .catch((e) => {
    console.log(e);
    console.log("??");
  });
```

previous log

```
文件路径： file:///data/user/0/com.pitayacreate.dev/cache/rn_image_picker_lib_temp_809478c6-a6b9-4bf4-b07a-620f9db1603b.jpg
[Error: No such file 'file:///data/user/0/com.pitayacreate.dev/cache/rn_image_picker_lib_temp_809478c6-a6b9-4bf4-b07a-620f9db1603b.jpg']
??
```

current log

```
文件路径： file:///data/user/0/com.pitayacreate.dev/cache/rn_image_picker_lib_temp_809478c6-a6b9-4bf4-b07a-620f9db1603b.jpg
hash sha256
dd57715f5920cff79eab3f64069c05bb6763b5160a0ca92c4f5559f62bd2cfc3
```

## Android

can use uri or path.

- uri, path starting with `file://`
- path, path starting with `/`

## iOS

can not use uri.

- `unlink` don't report an error, file not deleted.

## DEMO

[blob-util-demo](https://github.com/onlyling/blob-util-demo)

## Summary

Use path instead of uri, or adapt it on iOS.
