### PR TITLE
Adding File Transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,14 @@ await ReactNativeBlobUtil.MediaCollection.writeToMediafile('content://....', // 
 );
 ````
 
+Copies and tranforms data from a file in the apps storage to an existing entry of the Media Store. NOTE: you must set a transformer on the file in order for the transformation to happen (see [Setting a File Transformer](#Setting-A-File-Transformer)).
+
+````js
+await ReactNativeBlobUtil.MediaCollection.writeToMediafileWithTransform('content://....', // content uri of the entry in the media storage
+        localpath // path to the file that should be copied
+);
+````
+
 #### copyToInternal
 Copies an entry form the media storage to the apps internal storage.
 ````js

--- a/README.md
+++ b/README.md
@@ -303,6 +303,26 @@ ReactNativeBlobUtil
 
 **These files won't be removed automatically, please refer to [Cache File Management](#user-content-cache-file-management)**
 
+**Use File Transformer**
+
+If you need to perform any processing on the bytes prior to it being written into storage (e.g. if you want it to be encrypted) then you can use `transform` option.  NOTE: you will need to set a transformer on the libray (see [Setting a File Transformer](#Setting-A-File-Transformer))
+
+```js
+ReactNativeBlobUtil
+        .config({
+            // response data will be saved to this path if it has access right.
+            path: dirs.DocumentDir + '/path-to-file.anything',
+            transform: true
+        })
+        .fetch('GET', 'http://www.example.com/file/example.zip', {
+            //some headers ..
+        })
+        .then((res) => {
+            // the path should be dirs.DocumentDir + 'path-to-file.anything'
+            console.log('The file saved to ', res.path())
+        })
+```
+
 #### Upload example : Dropbox [files-upload](https://www.dropbox.com/developers/documentation/http/documentation#files-upload) API
 
 `react-native-blob-util` will convert the base64 string in `body` to binary format using native API, this process is done in a separated thread so that it won't block your GUI.
@@ -697,8 +717,10 @@ File Access APIs
 - [dirs](https://github.com/RonRadtke/react-native-blob-util/wiki/File-System-Access-API#dirs)
 - [createFile](https://github.com/RonRadtke/react-native-blob-util/wiki/File-System-Access-API#createfilepath-data-encodingpromise)
 - [writeFile (0.6.0)](https://github.com/RonRadtke/react-native-blob-util/wiki/File-System-Access-API#writefilepathstring-contentstring--array-encodingstring-appendbooleanpromise)
+- writeFileWithTransform
 - [appendFile (0.6.0) ](https://github.com/RonRadtke/react-native-blob-util/wiki/File-System-Access-API#appendfilepathstring-contentstring--arraynumber-encodingstring-promisenumber)
 - [readFile (0.6.0)](https://github.com/RonRadtke/react-native-blob-util/wiki/File-System-Access-API#readfilepath-encodingpromise)
+- readFileWithTransform
 - [readStream](https://github.com/RonRadtke/react-native-blob-util/wiki/File-System-Access-API#readstreampath-encoding-buffersize-interval-promisernfbreadstream)
 - [hash (0.10.9)](https://github.com/RonRadtke/react-native-blob-util/wiki/File-System-Access-API#hashpath-algorithm-promise)
 - [writeStream](https://github.com/RonRadtke/react-native-blob-util/wiki/File-System-Access-API#writestreampathstring-encodingstringpromise)
@@ -903,12 +925,58 @@ ReactNativeBlobUtil.config({
         })
 ```
 
+### Transform Files
+
+Sometimes you may need the files to be transformed after reading from storage or before writing into storage (eg encryption/decyrption). In order to perform the transformations, use `readFileWithTransform` and `writeFileWithTransform`. NOTE: you must set a transformer on the file in order for the transformation to happen (see [Setting a File Transformer](#Setting-A-File-Transformer)).
+
 ## Web API Polyfills
 
 After `0.8.0` we've made some [Web API polyfills](https://github.com/RonRadtke/react-native-blob-util/wiki/Web-API-Polyfills-(experimental)) that makes some browser-based library available in RN.
 
 - Blob
 - XMLHttpRequest (Use our implementation if you're going to use it with Blob)
+
+
+## Setting A File Transformer
+
+Setting a file transformer will allow you to specify how data should be transformed whenever the library is writing into storage or reading from storage. A use case for this is if you want the files handled by this library to be encrypted. 
+
+If you want to use a file transformer, you must implement an interface defined in:
+
+[ReactNativeBlobUtilFileTransformer.h (iOS)](/ios/ReactNativeBlobUtilFileTransformer.h)
+
+[ReactNativeBlobUtilFileTransformer.java (Android)](/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFileTransformer.java)
+
+Then you set the File Transformer during app startup
+
+Android:
+```java
+public class MainApplication extends Application implements ReactApplication {
+    ...
+    @Override
+    public void onCreate() {
+       ...
+       ReactNativeBlobUtilFileTransformer.sharedFileTransformer = new MyCustomEncryptor(); 
+       ...
+    }
+```
+
+iOS:
+```m
+@implementation AppDelegate
+...
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    ...
+    [ReactNativeBlobUtilFileTransformer setFileTransformer: MyCustomEncryptor.new];
+    ...
+}
+```
+
+Here are the places where the transformer would apply 
+- Reading a file from the file system  
+- Writing a file into the file system
+- Http response is downloaded to storage directly
 
 ## Performance Tips
 

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtil.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtil.java
@@ -233,11 +233,11 @@ public class ReactNativeBlobUtil extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void readFile(final String path, final String encoding, final Promise promise) {
+    public void readFile(final String path, final String encoding, final boolean transformFile, final Promise promise) {
         threadPool.execute(new Runnable() {
             @Override
             public void run() {
-                ReactNativeBlobUtilFS.readFile(path, encoding, promise);
+                ReactNativeBlobUtilFS.readFile(path, encoding, transformFile, promise);
             }
         });
     }
@@ -253,11 +253,11 @@ public class ReactNativeBlobUtil extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void writeFile(final String path, final String encoding, final String data, final boolean append, final Promise promise) {
+    public void writeFile(final String path, final String encoding, final String data, final boolean transformFile, final boolean append, final Promise promise) {
         threadPool.execute(new Runnable() {
             @Override
             public void run() {
-                ReactNativeBlobUtilFS.writeFile(path, encoding, data, append, promise);
+                ReactNativeBlobUtilFS.writeFile(path, encoding, data, transformFile, append, promise);
             }
         });
     }

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtil.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtil.java
@@ -438,8 +438,8 @@ public class ReactNativeBlobUtil extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void writeToMediaFile(String fileUri, String path, Promise promise) {
-        boolean res = ReactNativeBlobUtilMediaCollection.writeToMediaFile(Uri.parse(fileUri), path, promise);
+    public void writeToMediaFile(String fileUri, String path, boolean transformFile, Promise promise) {
+        boolean res = ReactNativeBlobUtilMediaCollection.writeToMediaFile(Uri.parse(fileUri), path, transformFile, promise);
         if(res) promise.resolve("Success");
     }
 
@@ -478,7 +478,7 @@ public class ReactNativeBlobUtil extends ReactContextBaseJavaModule {
             return;
         }
 
-        boolean res = ReactNativeBlobUtilMediaCollection.writeToMediaFile(fileuri, path, promise);
+        boolean res = ReactNativeBlobUtilMediaCollection.writeToMediaFile(fileuri, path, false, promise);
         if(res) promise.resolve(fileuri.toString());
     }
 

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilConfig.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilConfig.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 class ReactNativeBlobUtilConfig {
 
     public Boolean fileCache;
+    public Boolean transformFile;
     public String path;
     public String appendExt;
     public ReadableMap addAndroidDownloads;
@@ -26,6 +27,7 @@ class ReactNativeBlobUtilConfig {
         if (options == null)
             return;
         this.fileCache = options.hasKey("fileCache") && options.getBoolean("fileCache");
+        this.transformFile = options.hasKey("transformFile") ? options.getBoolean("transformFile") : false;
         this.path = options.hasKey("path") ? options.getString("path") : null;
         this.appendExt = options.hasKey("appendExt") ? options.getString("appendExt") : "";
         this.trusty = options.hasKey("trusty") && options.getBoolean("trusty");

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFileTransformer.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFileTransformer.java
@@ -1,0 +1,10 @@
+package com.ReactNativeBlobUtil;
+
+public class ReactNativeBlobUtilFileTransformer {
+    public interface FileTransformer {
+        public byte[] onWriteFile(byte[] data);
+        public byte[] onReadFile(byte[] data);
+    }
+
+    public static ReactNativeBlobUtilFileTransformer.FileTransformer sharedFileTransformer;
+}

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
@@ -87,6 +87,12 @@ public class ReactNativeBlobUtilReq extends BroadcastReceiver implements Runnabl
         BASE64
     }
 
+    private boolean shouldTransformFile() {
+        return this.options.transformFile &&
+            // Can only process if it's written to a file
+            (this.options.fileCache || this.options.path != null);
+    }
+
     public static HashMap<String, Call> taskTable = new HashMap<>();
     public static HashMap<String, Long> androidDownloadManagerTaskTable = new HashMap<>();
     static HashMap<String, ReactNativeBlobUtilProgressConfig> progressReport = new HashMap<>();
@@ -124,7 +130,9 @@ public class ReactNativeBlobUtilReq extends BroadcastReceiver implements Runnabl
         this.rawRequestBodyArray = arrayBody;
         this.client = client;
 
-        if (this.options.fileCache || this.options.path != null)
+        // If transformFile is specified, we first want to get the response back in memory so we can
+        // encrypt it wholesale and at that point, write it into the file storage.
+        if((this.options.fileCache || this.options.path != null) && !this.shouldTransformFile())
             responseType = ResponseType.FileStorage;
         else
             responseType = ResponseType.KeepInMemory;
@@ -557,6 +565,23 @@ public class ReactNativeBlobUtilReq extends BroadcastReceiver implements Runnabl
                     // response data directly pass to JS context as string.
                     else {
                         byte[] b = resp.body().bytes();
+                        // If process file option is turned on, we first keep response in memory and then stream that content
+                        // after processing
+                        if (this.shouldTransformFile()) {
+                            if (ReactNativeBlobUtilFileTransformer.sharedFileTransformer == null) {
+                                throw new IllegalStateException("Write file with transform was specified but the shared file transformer is not set");
+                            }
+                            this.destPath = this.destPath.replace("?append=true", "");
+                            File file = new File(this.destPath);
+                            if (!file.exists()) {
+                                file.createNewFile();
+                            }
+                            try (FileOutputStream fos = new FileOutputStream(file)) {
+                                fos.write(ReactNativeBlobUtilFileTransformer.sharedFileTransformer.onWriteFile(b));
+                            }
+                            callback.invoke(null, ReactNativeBlobUtilConst.RNFB_RESPONSE_PATH, this.destPath);
+                            return;
+                        }
                         if (responseFormat == ResponseFormat.BASE64) {
                             callback.invoke(null, ReactNativeBlobUtilConst.RNFB_RESPONSE_BASE64, android.util.Base64.encodeToString(b, Base64.NO_WRAP));
                             return;

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
@@ -578,6 +578,9 @@ public class ReactNativeBlobUtilReq extends BroadcastReceiver implements Runnabl
                             }
                             try (FileOutputStream fos = new FileOutputStream(file)) {
                                 fos.write(ReactNativeBlobUtilFileTransformer.sharedFileTransformer.onWriteFile(b));
+                            } catch(Exception e) {
+                                callback.invoke("Error from file transformer:" + e.getLocalizedMessage(), null);
+                                return;
                             }
                             callback.invoke(null, ReactNativeBlobUtilConst.RNFB_RESPONSE_PATH, this.destPath);
                             return;

--- a/fs.js
+++ b/fs.js
@@ -160,7 +160,20 @@ function readFile(path: string, encoding: string = 'utf8'): Promise<any> {
     if (typeof path !== 'string') {
         return Promise.reject(addCode('EINVAL', new TypeError('Missing argument "path" ')));
     }
-    return ReactNativeBlobUtil.readFile(path, encoding);
+    return ReactNativeBlobUtil.readFile(path, encoding, false);
+}
+
+/**
+ * Reads the file, then transforms it before returning the content
+ * @param  {string} path Path of the file.
+ * @param  {'base64' | 'utf8' | 'ascii'} encoding Encoding of read stream.
+ * @return {Promise<Array<number> | string>}
+ */
+function readFileWithTransform(path: string, encoding: string = 'utf8'): Promise<any> {
+    if (typeof path !== 'string') {
+        return Promise.reject(addCode('EINVAL', new TypeError('Missing argument "path" ')))
+    }
+    return ReactNativeBlobUtil.readFile(path, encoding, true);
 }
 
 /**
@@ -186,7 +199,31 @@ function writeFile(path: string, data: string | Array<number>, encoding: ?string
             return Promise.reject(addCode('EINVAL', new TypeError(`"data" must be a String when encoding is "utf8" or "base64", but it is "${typeof data}"`)));
         }
         else
-            return ReactNativeBlobUtil.writeFile(path, encoding, data, false);
+            return ReactNativeBlobUtil.writeFile(path, encoding, data, false, false);
+    }
+}
+
+/**
+ * Transforms the data and then writes to the file.
+ * @param  {string} path  Path of the file.
+ * @param  {string | number[]} data Data to write to the file.
+ * @param  {string} encoding Encoding of data (Optional).
+ * @return {Promise}
+ */
+function writeFileWithTransform(path: string, data: string | Array<number>, encoding: ?string = 'utf8'): Promise {
+    if (typeof path !== 'string') {
+        return Promise.reject(addCode('EINVAL', new TypeError('Missing argument "path" ')))
+    }
+    if (encoding.toLocaleLowerCase() === 'ascii') {
+        return Promise.reject(addCode('EINVAL', new TypeError('ascii is not supported for converted files')))
+    }
+    else {
+        if (typeof data !== 'string') {
+            return Promise.reject(addCode('EINVAL', new TypeError(`"data" must be a String when encoding is "utf8" or "base64", but it is "${typeof data}"`)))
+        }
+
+        else
+            return ReactNativeBlobUtil.writeFile(path, encoding, data, true, false)
     }
 }
 
@@ -415,6 +452,8 @@ export default {
     cp,
     writeStream,
     writeFile,
+    writeFileWithTransform,
+    readFileWithTransform,
     appendFile,
     pathForAppGroup,
     syncPathAppGroup,

--- a/index.d.ts
+++ b/index.d.ts
@@ -831,6 +831,13 @@ export interface MediaCollection {
     writeToMediafile(uri: string, path: string): Promise<string>
 
     /**
+     * Copies and transforms an existing file to a mediastore file. Make sure FileTransformer is set
+     * @param uri URI of the destination mediastore file
+     * @param path Path to the existing file which should be copied
+     */
+    writeToMediafileWithTransform(uri: string, path: string): Promise<string>
+
+    /**
      * Copies a file from the mediastore to the apps internal storage
      * @param contenturi URI of the mediastore file
      * @param destpath Path for the file in the internal storage

--- a/index.d.ts
+++ b/index.d.ts
@@ -399,6 +399,14 @@ export interface FS {
      */
     writeFile(path: string, data: string | number[], encoding?: Encoding): Promise<void>;
 
+    /**
+     * Processes the data and then writes to the file.
+     * @param  path  Path of the file.
+     * @param  data Data to write to the file.
+     * @param  encoding Encoding of data (Optional).
+     */
+     writeFileWithTransform(path: string, data: string | number[], encoding?: Encoding): Promise<void>;
+
     appendFile(path: string, data: string | number[], encoding?: Encoding | "uri"): Promise<number>;
 
     /**
@@ -407,6 +415,13 @@ export interface FS {
      * @param  encoding Encoding of read stream.
      */
     readFile(path: string, encoding: Encoding, bufferSize?: number): Promise<any>;
+
+    /**
+     * Reads from a file and then processes the data before returning
+     * @param  path Path of the file.
+     * @param  encoding Encoding of read stream.
+     */
+     readFileWithTransform(path: string, encoding: Encoding, bufferSize?: number): Promise<any>;
 
     /**
      * Check if file exists and if it is a folder.
@@ -697,6 +712,13 @@ export interface ReactNativeBlobUtilConfig {
      * file will stored in App's own root folder with file name template ReactNativeBlobUtil_tmp${timestamp}.
      */
     fileCache?: boolean;
+
+    /**
+     * Set this property to true if you want the data to be processed before it gets written onto disk.
+     * This only has effect if the FileTransformer has been registered and the library is configured to write
+     * response onto disk.
+     */
+    transformFile?: boolean;
 
     /**
      * Set this property to change temp file extension that created by fetch response data.

--- a/ios/ReactNativeBlobUtil.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeBlobUtil.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		8C4801A6200CF71700FED7ED /* ReactNativeBlobUtilRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C4801A5200CF71700FED7ED /* ReactNativeBlobUtilRequest.m */; };
+		9FD8D3C326F1736000009F35 /* ReactNativeBlobUtilFileTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FD8D3C226F1736000009F35 /* ReactNativeBlobUtilFileTransformer.m */; };
 		A158F4271D052E49006FFD38 /* ReactNativeBlobUtilFS.m in Sources */ = {isa = PBXBuildFile; fileRef = A158F4261D052E49006FFD38 /* ReactNativeBlobUtilFS.m */; };
 		A158F42D1D0535BB006FFD38 /* ReactNativeBlobUtilConst.m in Sources */ = {isa = PBXBuildFile; fileRef = A158F42C1D0535BB006FFD38 /* ReactNativeBlobUtilConst.m */; };
 		A158F4301D0539DB006FFD38 /* ReactNativeBlobUtilNetwork.m in Sources */ = {isa = PBXBuildFile; fileRef = A158F42F1D0539DB006FFD38 /* ReactNativeBlobUtilNetwork.m */; };
@@ -32,6 +33,8 @@
 /* Begin PBXFileReference section */
 		8C4801A4200CF71700FED7ED /* ReactNativeBlobUtilRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactNativeBlobUtilRequest.h; sourceTree = "<group>"; };
 		8C4801A5200CF71700FED7ED /* ReactNativeBlobUtilRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ReactNativeBlobUtilRequest.m; sourceTree = "<group>"; };
+		9FD8D3C126F1709A00009F35 /* ReactNativeBlobUtilFileTransformer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactNativeBlobUtilFileTransformer.h; sourceTree = "<group>"; };
+		9FD8D3C226F1736000009F35 /* ReactNativeBlobUtilFileTransformer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ReactNativeBlobUtilFileTransformer.m; sourceTree = "<group>"; };
 		A158F4261D052E49006FFD38 /* ReactNativeBlobUtilFS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReactNativeBlobUtilFS.m; sourceTree = "<group>"; };
 		A158F4281D052E57006FFD38 /* ReactNativeBlobUtilFS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactNativeBlobUtilFS.h; sourceTree = "<group>"; };
 		A158F4291D0534A9006FFD38 /* ReactNativeBlobUtilConst.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactNativeBlobUtilConst.h; sourceTree = "<group>"; };
@@ -69,6 +72,8 @@
 		A15C30051CD25C330074CB35 = {
 			isa = PBXGroup;
 			children = (
+				9FD8D3C226F1736000009F35 /* ReactNativeBlobUtilFileTransformer.m */,
+				9FD8D3C126F1709A00009F35 /* ReactNativeBlobUtilFileTransformer.h */,
 				A19B48241D98102400E6868A /* ReactNativeBlobUtilProgress.m */,
 				A19B48231D98100800E6868A /* ReactNativeBlobUtilProgress.h */,
 				A1F950181D7E9134002A95A6 /* IOS7Polyfill.h */,
@@ -156,6 +161,7 @@
 				A166D1AA1CE0647A00273590 /* ReactNativeBlobUtil.h in Sources */,
 				8C4801A6200CF71700FED7ED /* ReactNativeBlobUtilRequest.m in Sources */,
 				A158F42D1D0535BB006FFD38 /* ReactNativeBlobUtilConst.m in Sources */,
+				9FD8D3C326F1736000009F35 /* ReactNativeBlobUtilFileTransformer.m in Sources */,
 				A158F4271D052E49006FFD38 /* ReactNativeBlobUtilFS.m in Sources */,
 				A158F4301D0539DB006FFD38 /* ReactNativeBlobUtilNetwork.m in Sources */,
 				A19B48251D98102400E6868A /* ReactNativeBlobUtilProgress.m in Sources */,

--- a/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.m
+++ b/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.m
@@ -252,9 +252,9 @@ RCT_EXPORT_METHOD(exists:(NSString *)path callback:(RCTResponseSenderBlock)callb
 }
 
 #pragma mark - fs.writeFile
-RCT_EXPORT_METHOD(writeFile:(NSString *)path encoding:(NSString *)encoding data:(NSString *)data append:(BOOL)append resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(writeFile:(NSString *)path encoding:(NSString *)encoding data:(NSString *)data transformFile:(BOOL)transformFile append:(BOOL)append resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [ReactNativeBlobUtilFS writeFile:path encoding:[NSString stringWithString:encoding] data:data append:append resolver:resolve rejecter:reject];
+    [ReactNativeBlobUtilFS writeFile:path encoding:[NSString stringWithString:encoding] data:data transformFile:transformFile append:append resolver:resolve rejecter:reject];
 }
 
 #pragma mark - fs.writeArray
@@ -494,11 +494,12 @@ RCT_EXPORT_METHOD(mkdir:(NSString *)path resolver:(RCTPromiseResolveBlock)resolv
 #pragma mark - fs.readFile
 RCT_EXPORT_METHOD(readFile:(NSString *)path
                   encoding:(NSString *)encoding
+                  transformFile:(BOOL) transformFile
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     
-    [ReactNativeBlobUtilFS readFile:path encoding:encoding onComplete:^(NSData * content, NSString * code, NSString * err) {
+    [ReactNativeBlobUtilFS readFile:path encoding:encoding transformFile:transformFile onComplete:^(NSData * content, NSString * code, NSString * err) {
         if(err != nil) {
             reject(code, err, nil);
             return;

--- a/ios/ReactNativeBlobUtilConst.h
+++ b/ios/ReactNativeBlobUtilConst.h
@@ -29,6 +29,7 @@ extern NSString *const AL_PREFIX;
 
 // config
 extern NSString *const CONFIG_USE_TEMP;
+extern NSString *const CONFIG_TRANSFORM_FILE;
 extern NSString *const CONFIG_FILE_PATH;
 extern NSString *const CONFIG_FILE_EXT;
 extern NSString *const CONFIG_TRUSTY;

--- a/ios/ReactNativeBlobUtilConst.m
+++ b/ios/ReactNativeBlobUtilConst.m
@@ -13,6 +13,7 @@ NSString *const AL_PREFIX = @"assets-library://";
 
 // fetch configs
 NSString *const CONFIG_USE_TEMP = @"fileCache";
+NSString *const CONFIG_TRANSFORM_FILE = @"transformFile";
 NSString *const CONFIG_FILE_PATH = @"path";
 NSString *const CONFIG_FILE_EXT = @"appendExt";
 NSString *const CONFIG_TRUSTY = @"trusty";

--- a/ios/ReactNativeBlobUtilFS.h
+++ b/ios/ReactNativeBlobUtilFS.h
@@ -72,7 +72,8 @@
 + (NSDictionary *) stat:(NSString *) path error:(NSError **) error;
 + (void) exists:(NSString *) path callback:(RCTResponseSenderBlock)callback;
 + (void) writeFileArray:(NSString *)path data:(NSArray *)data append:(BOOL)append resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
-+ (void) writeFile:(NSString *)path encoding:(NSString *)encoding data:(NSString *)data append:(BOOL)append resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
++ (void) writeFile:(NSString *)path encoding:(NSString *)encoding data:(NSString *)data transformFile:(BOOL)transformFile append:(BOOL)append resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
++ (void) readFile:(NSString *)path encoding:(NSString *)encoding transformFile:(BOOL)transformFile onComplete:(void (^)(NSData * content, NSString* code, NSString * errMsg))onComplete;
 + (void) readFile:(NSString *)path encoding:(NSString *)encoding onComplete:(void (^)(NSData * content, NSString* code, NSString * errMsg))onComplete;
 + (void) readAssetFile:(NSData *)assetUrl completionBlock:(void(^)(NSData * content))completionBlock failBlock:(void(^)(NSError * err))failBlock;
 + (void) slice:(NSString *)path

--- a/ios/ReactNativeBlobUtilFS.m
+++ b/ios/ReactNativeBlobUtilFS.m
@@ -538,7 +538,13 @@ NSMutableDictionary *fileStreams = nil;
         if (transformFile) {
             NSObject<FileTransformer>* fileTransformer = [ReactNativeBlobUtilFileTransformer getFileTransformer];
             if (fileTransformer) {
-                fileContent = [fileTransformer onReadFile:fileContent];
+                @try{
+                    fileContent = [fileTransformer onReadFile:fileContent];
+                } @catch (NSException * ex)
+                {
+                    onComplete(nil, @"EUNSPECIFIED", [NSString stringWithFormat:@"Exception on File Transformer: '%@' ", [ex description]]);
+                    return;
+                }
             } else {
                 onComplete(nil, @"EUNSPECIFIED", @"Transform specified but transformer not set");
                 return;

--- a/ios/ReactNativeBlobUtilFileTransformer.h
+++ b/ios/ReactNativeBlobUtilFileTransformer.h
@@ -1,0 +1,24 @@
+//  ReactNativeBlobUtilFileTransformer.h
+//  ReactNativeBlobUtil
+//
+
+#ifndef ReactNativeBlobUtilDataConverter_h
+#define ReactNativeBlobUtilDataConverter_h
+
+#import <UIKit/UIKit.h>
+
+
+@protocol FileTransformer <NSObject>
+- (NSData*) onWriteFile:(NSData*)data;
+- (NSData*) onReadFile:(NSData*)data;
+@end
+
+@interface ReactNativeBlobUtilFileTransformer : NSObject
+
++ (void) setFileTransformer:(NSObject<FileTransformer>*) fileTransformer;
++ (NSObject<FileTransformer>*) getFileTransformer;
+
+@end
+
+
+#endif /* ReactNativeBlobUtilFileTransformer_h */

--- a/ios/ReactNativeBlobUtilFileTransformer.m
+++ b/ios/ReactNativeBlobUtilFileTransformer.m
@@ -1,0 +1,21 @@
+//  ReactNativeBlobUtilFileTransformer.m
+//  ReactNativeBlobUtil
+//
+
+#import "ReactNativeBlobUtilFileTransformer.h"
+
+static NSObject<FileTransformer> *sharedFileTransformer;
+
+@implementation ReactNativeBlobUtilFileTransformer
+
++ (void) setFileTransformer:(NSObject<FileTransformer> *)fileTransformer {
+     sharedFileTransformer = fileTransformer;
+}
+
++ (NSObject<FileTransformer>*) getFileTransformer {
+    return sharedFileTransformer;
+}
+
+@end
+
+// PHOENIX:PATCH-PACKAGE END

--- a/ios/ReactNativeBlobUtilReqBuilder.m
+++ b/ios/ReactNativeBlobUtilReqBuilder.m
@@ -119,7 +119,7 @@
                     if([orgPath hasPrefix:AL_PREFIX])
                     {
                         
-                        [ReactNativeBlobUtilFS readFile:orgPath encoding:nil onComplete:^(id content, NSString* code, NSString * err) {
+                        [ReactNativeBlobUtilFS readFile:orgPath encoding:nil transformFile:false onComplete:^(id content, NSString* code, NSString * err) {
                             if(err != nil)
                             {
                                 onComplete(nil, nil);
@@ -223,7 +223,7 @@
                         NSString * orgPath = [content substringFromIndex:[FILE_PREFIX length]];
                         orgPath = [ReactNativeBlobUtilFS getPathOfAsset:orgPath];
 
-                        [ReactNativeBlobUtilFS readFile:orgPath encoding:nil onComplete:^(NSData *content, NSString* code, NSString * err) {
+                        [ReactNativeBlobUtilFS readFile:orgPath encoding:nil transformFile:false onComplete:^(NSData *content, NSString* code, NSString * err) {
                             if(err != nil)
                             {
                                 onComplete(formData, YES);

--- a/ios/ReactNativeBlobUtilRequest.m
+++ b/ios/ReactNativeBlobUtilRequest.m
@@ -406,8 +406,13 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
             if (!fileTransformer) {
                 errMsg = @"Transform file specified but file transfomer not set";
             } else {
-                NSData* transformedData = [fileTransformer onWriteFile:respData];
-                [writeStream write:[transformedData bytes] maxLength:[transformedData length]];
+                @try{
+                    NSData* transformedData = [fileTransformer onWriteFile:respData];
+                    [writeStream write:[transformedData bytes] maxLength:[transformedData length]];
+                } @catch(NSException * ex)
+                {
+                    errMsg = [NSString stringWithFormat:@"Exception on File Transformer: '%@' ", [ex description]];
+                }
             }
         }
         [writeStream close];

--- a/ios/ReactNativeBlobUtilRequest.m
+++ b/ios/ReactNativeBlobUtilRequest.m
@@ -10,6 +10,7 @@
 
 #import "ReactNativeBlobUtilFS.h"
 #import "ReactNativeBlobUtilConst.h"
+#import "ReactNativeBlobUtilFileTransformer.h"
 #import "ReactNativeBlobUtilReqBuilder.h"
 
 #import "IOS7Polyfill.h"
@@ -155,6 +156,12 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
             destPath = path;
         } else {
             destPath = [ReactNativeBlobUtilFS getTempPath:cacheKey withExtension:[self.options valueForKey:CONFIG_FILE_EXT]];
+        }
+
+        // We still need to initialize this as a placeholder in memory before we perform
+        // the conversion
+        if ([self ShouldTransformFile]) {
+            respData = [[NSMutableData alloc] init];
         }
     } else {
         respData = [[NSMutableData alloc] init];
@@ -333,7 +340,9 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
         chunkString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     }
 
-    if (respFile) {
+    // If we need to process the data, we defer writing into the file until the we have all the data, at which point
+    // we can perform the processing and then write into the file
+    if (respFile && ![self ShouldTransformFile]) {
         [writeStream write:[data bytes] maxLength:[data length]];
     } else {
         [respData appendData:data];
@@ -390,6 +399,17 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
     }
 
     if (respFile) {
+        if ([self ShouldTransformFile]) {
+            // At this point, we have the data that we deferred to write into a file. We can now
+            // perform the conversion and write the converted data into the file.
+            NSObject<FileTransformer>* fileTransformer = [ReactNativeBlobUtilFileTransformer getFileTransformer];
+            if (!fileTransformer) {
+                errMsg = @"Transform file specified but file transfomer not set";
+            } else {
+                NSData* transformedData = [fileTransformer onWriteFile:respData];
+                [writeStream write:[transformedData bytes] maxLength:[transformedData length]];
+            }
+        }
         [writeStream close];
         rnfbRespType = RESP_TYPE_PATH;
         respStr = destPath;
@@ -428,6 +448,10 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
     receivedBytes = 0;
     [session finishTasksAndInvalidate];
 
+}
+
+- (BOOL) ShouldTransformFile{
+    return [[options valueForKey:CONFIG_TRANSFORM_FILE] boolValue];
 }
 
 // upload progress handler

--- a/mediacollection.js
+++ b/mediacollection.js
@@ -9,7 +9,11 @@ function createMediafile(fd: filedescriptor, mediatype: string): Promise {
 }
 
 function writeToMediafile(uri: string, path: string) {
-    return ReactNativeBlobUtil.writeToMediaFile(uri, path);
+    return ReactNativeBlobUtil.writeToMediaFile(uri, path, false);
+}
+
+function writeToMediafileWithTransform(uri: string, path: string) {
+    return ReactNativeBlobUtil.writeToMediaFile(uri, path, true);
 }
 
 function copyToInternal(contenturi: string, destpath: string) {

--- a/mediacollection.js
+++ b/mediacollection.js
@@ -31,6 +31,7 @@ function copyToMediaStore(fd: filedescriptor, mediatype: string, path: string) {
 export default {
     createMediafile,
     writeToMediafile,
+    writeToMediafileWithTransform,
     copyToInternal,
     getBlob,
     copyToMediaStore

--- a/types.js
+++ b/types.js
@@ -3,6 +3,7 @@ export type ReactNativeBlobUtilConfig = {
   Progress: any,
   UploadProgress: any,
   fileCache : bool,
+  transformFile: boolean;
   path : string,
   appendExt : string,
   session : string,


### PR DESCRIPTION
This change adds a concept of an optional "transformer" that allows preprocessing before writing and after reading bytes from storage via this library. 

The transformer can be set natively. The transformers can be triggered when writing to file, reading from file, writing to media file (on android), and writing the bytes of a response from a RNBU request. 

To give an example of how this might be used, in our instance of the app, the transformer is used to encrypt/decrypt content to make sure everything written to disk is encrypted. The intent with the transformer is to be as generic as possible to allow any type of byte manipulation that should be done in the various scenarios that's addressed. 

I updated the readme with documentations around this new functionality.  