### PR TITLE
🐛 Fix Task Scoping for Fetch Cancellation

### DIFF
--- a/polyfill/Fetch.js
+++ b/polyfill/Fetch.js
@@ -59,10 +59,12 @@ class ReactNativeBlobUtilFetchPolyfill {
             // task.then is not, so we have to extend task.then with progress and
             // cancel function
             let progressHandler, uploadHandler, cancelHandler;
+            let scopedTask = null;
             let statefulPromise = promise
                 .then((body) => {
                     let task = RNconfig(config)
                         .fetch(options.method, url, options.headers, body);
+                    scopedTask = task;
                     if (progressHandler)
                         task.progress(progressHandler);
                     if (uploadHandler)
@@ -87,8 +89,8 @@ class ReactNativeBlobUtilFetchPolyfill {
             };
             statefulPromise.cancel = () => {
                 cancelHandler = true;
-                if (task.cancel)
-                    task.cancel();
+                if (scopedTask && scopedTask.cancel)
+                    scopedTask.cancel();
             };
 
             return statefulPromise;


### PR DESCRIPTION
Fixes the outstanding error in the joltup repo:
https://github.com/joltup/rn-fetch-blob/issues/687

This commit is pretty much just copypasta from @nadav2051 but applied to this new fork.

The assigned `task` variable is not available on the cancel method. This
moves the assignment outside the promise scope and allows it to be
correctly called.