### PR TITLE
append file - add in missing parameter

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -243,7 +243,7 @@ function appendFile(path: string, data: string | Array<number>, encoding?: strin
             return Promise.reject(addCode('EINVAL'), new TypeError(`"data" must be a String when encoding is "utf8" or "base64", but it is "${typeof data}"`));
         }
         else
-            return ReactNativeBlobUtil.writeFile(path, encoding, data, true);
+            return ReactNativeBlobUtil.writeFile(path, encoding, data, false, true);
     }
 }
 


### PR DESCRIPTION
The fs.js `appendFile()` call to `ReactNativeBlobUtil.writeFile()` was setting `transform` to `true` and missing out the required `append` boolean value. As a result of this uploads were sometimes failing.

This changes the call to be `transform: false` and `append: true`.

More info here: https://github.com/RonRadtke/react-native-blob-util/issues/131