### PR TITLE
Fixed export error, use named export

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,9 +56,9 @@ if (!ReactNativeBlobUtil || !ReactNativeBlobUtil.fetchBlobForm || !ReactNativeBl
 }
 
 export {ReactNativeBlobUtilConfig, ReactNativeBlobUtilResponseInfo, ReactNativeBlobUtilStream} from './types';
-export URIUtil from './utils/uri';
+export { URIUtil } from './utils/uri';
 export {FetchBlobResponse} from './class/ReactNativeBlobUtilBlobResponse';
-export getUUID from './utils/uuid';
+export { getUUID } from './utils/uuid';
 export default {
     fetch,
     base64,


### PR DESCRIPTION
While transpiling with typescript this error will occur:
```
Error while parsing /Users/yourusername/projectpath/node_modules/react-native-blob-util/index.js
Line 58, column 0: Declaration or statement expected.
```

This is because the export must be named. It doesn't look like the export is used directly and TypeScript definitions aren't showing it either but it should be correct code to avoid blocking compilation.