### PR TITLE
Fix type declaration for `close()` in interface `ReactNativeBlobUtilWriteStream`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -490,7 +490,7 @@ export interface ReactNativeBlobUtilWriteStream {
 
     write(data: string): Promise<void>;
 
-    close(): void;
+    close(): Promise<void>;
 }
 
 export interface ReactNativeBlobUtilReadStream {


### PR DESCRIPTION
The type declaration did not match the implementation.