### PR TITLE
Remove CHECK_LICENSE permission

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ReactNativeBlobUtil">
 
-    <!-- Required to access Google Play Licensing -->
-    <uses-permission android:name="com.android.vending.CHECK_LICENSE" />
-
     <!-- Required to download files from Google Play -->
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
Recently realized this permission got added to my project after pulling in this as a dependency, which was surprising since I saw the alert on F-Droid.  This seems like a permission that should be added by the app developer if needed, not something intrinsically required/added by this library.