### PR TITLE
Prevent potential divide by 0 error

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
@@ -197,7 +197,7 @@ public class ReactNativeBlobUtilReq extends BroadcastReceiver implements Runnabl
                             cursor.close();
 
                             ReactNativeBlobUtilProgressConfig reportConfig = getReportProgress(taskId);
-                            float progress = (total != -1) ? written / total : 0;
+                            float progress = (total > 0) ? written / (float) total : 0;
 
                             if (reportConfig != null && reportConfig.shouldReport(progress /* progress */)) {
                                 WritableMap args = Arguments.createMap();


### PR DESCRIPTION
I haven't experienced this myself but I had a user report that at least in a simulator they're sometimes getting a divide by 0 error here with a specific server, so I figure it's probably safest to prevent that form happening here anyway.  Also cast the integer to float for division.

Related issue with error/stack trace info: https://github.com/austinried/subtracks/issues/119