### PR TITLE
Fix `getUUID` and `URIUtil` re-exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,9 +56,9 @@ if (!ReactNativeBlobUtil || !ReactNativeBlobUtil.fetchBlobForm || !ReactNativeBl
 }
 
 export {ReactNativeBlobUtilConfig, ReactNativeBlobUtilResponseInfo, ReactNativeBlobUtilStream} from './types';
-export { URIUtil } from './utils/uri';
+export * as URIUtil from './utils/uri';
 export {FetchBlobResponse} from './class/ReactNativeBlobUtilBlobResponse';
-export { getUUID } from './utils/uuid';
+export * as getUUID from './utils/uuid';
 export default {
     fetch,
     base64,


### PR DESCRIPTION
`getUUID` and `URIUtil` are default exports, you need to use the `export * as …` syntax to re-exports them.

As noted in #136 which made this (incorrect) change, those 2 exports never worked and do not appear in type definitions, so maybe the correct fix is to remove them entirely?

I spotted this by using https://microsoft.github.io/rnx-kit/docs/tools/metro-serializer-esbuild in my project, which uses `esbuild` to optimise the bundle code, and it error-ed because of this invalid export.

This PR fixes the issue when tested locally with my setup, but again those 2 exports probably never worked so I dont think anybody used them.