### PR TITLE
 'boolean java.lang.String.isEmpty()' on a null object reference on certain Android phones.

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
@@ -297,7 +297,7 @@ public class ReactNativeBlobUtilReq extends BroadcastReceiver implements Runnabl
 
         // find cached result if `key` property exists
         String cacheKey = this.taskId;
-        String ext = this.options.appendExt.isEmpty() ? "" : "." + this.options.appendExt;
+        String ext = (this.options.appendExt == null || this.options.appendExt.isEmpty()) ? "" : "." + this.options.appendExt;
 
         if (this.options.key != null) {
             cacheKey = ReactNativeBlobUtilUtils.getMD5(this.options.key);
@@ -402,7 +402,7 @@ public class ReactNativeBlobUtilReq extends BroadcastReceiver implements Runnabl
 
                 if (rawRequestBodyArray != null) {
                     requestType = RequestType.Form;
-                } else if (cType.isEmpty()) {
+                } else if (cType == null || cType.isEmpty()) {
                     if (!cType.equalsIgnoreCase("")) {
                         builder.header("Content-Type", "application/octet-stream");
                     }

--- a/android/src/main/java/com/ReactNativeBlobUtil/Utils/MimeType.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/Utils/MimeType.java
@@ -27,7 +27,7 @@ public class MimeType {
     public static String getFullFileName(String name, String mimeType) {
         // Prior to API 29, MimeType.BINARY_FILE has no file extension
         String ext = MimeType.getExtensionFromMimeType(mimeType);
-        if (ext.isEmpty() || name.endsWith("." + "ext")) return name;
+        if ((ext == null || ext.isEmpty()) || name.endsWith("." + "ext")) return name;
         else {
             String fn = name + "." + ext;
             if (fn.endsWith(".")) return StringUtils.stripEnd(fn, ".");


### PR DESCRIPTION
We observed that some Android phones were crashing when executing `ReactNativeBlobUtil.MediaCollection.copyToMediaStore`.

The crash log was showing

`Attempt to invoke virtual method 'boolean java.lang.String.isEmpty()' on a null object reference.`

Unfortunately, none of the devices I have were crashing in this manner, and trying to debug on the few phones that the crash was observed on was impossible for us.

In this push, I am just adding a null check in all the places that perform `.isEmpty()` check. I already tested the implementation and indeed, one of these `.isEmpty()` checks was responsible for the crash.

Just in case if this will be of any help, one of the phones that were crashing is a Samsung Galaxy S8 running Android 8.