### PR TITLE
fix: with react-native-web product build will `export 'URIUtil' (reexported as 'URIUtil') was not found`

### DIFF
--- a/index.web.js
+++ b/index.web.js
@@ -1,0 +1,1 @@
+export default {};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "react-native-blob-util",
     "version": "0.17.0",
     "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
-    "main": "index.js",
+    "main": "index",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
     },


### PR DESCRIPTION
e.g. when `npm run build-web` in https://github.com/flyskywhy/PixelShapeRN/tree/v1.1.23