### PR TITLE
Add Custom Error for cancel task reject

### DIFF
--- a/class/ReactNativeBlobUtilCancelError.js
+++ b/class/ReactNativeBlobUtilCancelError.js
@@ -1,0 +1,10 @@
+class CanceledFetchError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = CanceledFetchErrorName;
+    }
+}
+
+export const CanceledFetchErrorName = 'ReactNativeBlobUtilCanceledFetch'
+
+export default CanceledFetchError

--- a/class/ReactNativeBlobUtilCanceledFetchError.js
+++ b/class/ReactNativeBlobUtilCanceledFetchError.js
@@ -1,10 +1,10 @@
+const CANCELED_FETCH_ERROR_NAME = 'ReactNativeBlobUtilCanceledFetch'
+
 class CanceledFetchError extends Error {
     constructor(message) {
         super(message);
-        this.name = CanceledFetchErrorName;
+        this.name = CANCELED_FETCH_ERROR_NAME
     }
 }
-
-export const CanceledFetchErrorName = 'ReactNativeBlobUtilCanceledFetch'
 
 export default CanceledFetchError

--- a/fetch.js
+++ b/fetch.js
@@ -4,7 +4,7 @@ import fs from "./fs";
 import getUUID from "./utils/uuid";
 import { DeviceEventEmitter } from "react-native";
 import { FetchBlobResponse } from "./class/ReactNativeBlobUtilBlobResponse";
-import { CanceledFetchError } from ".class/ReactNativeBlobUtilCanceledFetchError";
+import CanceledFetchError from "./class/ReactNativeBlobUtilCanceledFetchError";
 import ReactNativeBlobUtil from "./codegenSpecs/NativeBlobUtils";
 
 const emitter = DeviceEventEmitter;

--- a/fetch.js
+++ b/fetch.js
@@ -1,9 +1,10 @@
-import {ReactNativeBlobUtilConfig} from "./types";
+import { ReactNativeBlobUtilConfig } from "./types";
 import URIUtil from "./utils/uri";
 import fs from "./fs";
 import getUUID from "./utils/uuid";
-import {DeviceEventEmitter} from "react-native";
-import {FetchBlobResponse} from "./class/ReactNativeBlobUtilBlobResponse";
+import { DeviceEventEmitter } from "react-native";
+import { FetchBlobResponse } from "./class/ReactNativeBlobUtilBlobResponse";
+import { CanceledFetchError } from ".class/ReactNativeBlobUtilCanceledFetchError";
 import ReactNativeBlobUtil from "./codegenSpecs/NativeBlobUtils";
 
 const emitter = DeviceEventEmitter;
@@ -55,7 +56,7 @@ emitter.addListener("ReactNativeBlobUtilMessage", (e) => {
  * @return {function} This method returns a `fetch` method instance.
  */
 export function config(options: ReactNativeBlobUtilConfig) {
-    return {fetch: fetch.bind(options)};
+    return { fetch: fetch.bind(options) };
 }
 
 /**
@@ -105,7 +106,7 @@ function fetchFile(options = {}, method, url, headers = {}, body): Promise {
                     stream.open();
                     info = {
                         state: "2",
-                        headers: {'source': 'system-fs'},
+                        headers: { 'source': 'system-fs' },
                         status: 200,
                         respType: 'text',
                         rnfbEncode: headers.encoding || 'utf8'
@@ -328,7 +329,7 @@ export function fetch(...args: any): Promise {
         subscriptionUpload.remove();
         stateEvent.remove();
         ReactNativeBlobUtil.cancelRequest(taskId, fn);
-        promiseReject(new Error("canceled"));
+        promiseReject(new CanceledFetchError("canceled"));
     };
     promise.taskId = taskId;
 

--- a/fetch.js
+++ b/fetch.js
@@ -1,9 +1,9 @@
-import { ReactNativeBlobUtilConfig } from "./types";
+import {ReactNativeBlobUtilConfig} from "./types";
 import URIUtil from "./utils/uri";
 import fs from "./fs";
 import getUUID from "./utils/uuid";
-import { DeviceEventEmitter } from "react-native";
-import { FetchBlobResponse } from "./class/ReactNativeBlobUtilBlobResponse";
+import {DeviceEventEmitter} from "react-native";
+import {FetchBlobResponse} from "./class/ReactNativeBlobUtilBlobResponse";
 import CanceledFetchError from "./class/ReactNativeBlobUtilCanceledFetchError";
 import ReactNativeBlobUtil from "./codegenSpecs/NativeBlobUtils";
 
@@ -56,7 +56,7 @@ emitter.addListener("ReactNativeBlobUtilMessage", (e) => {
  * @return {function} This method returns a `fetch` method instance.
  */
 export function config(options: ReactNativeBlobUtilConfig) {
-    return { fetch: fetch.bind(options) };
+    return {fetch: fetch.bind(options)};
 }
 
 /**
@@ -106,7 +106,7 @@ function fetchFile(options = {}, method, url, headers = {}, body): Promise {
                     stream.open();
                     info = {
                         state: "2",
-                        headers: { 'source': 'system-fs' },
+                        headers: {'source': 'system-fs'},
                         status: 200,
                         respType: 'text',
                         rnfbEncode: headers.encoding || 'utf8'

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@
 export const ReactNativeBlobUtil: ReactNativeBlobUtilStatic;
 export type ReactNativeBlobUtil = ReactNativeBlobUtilStatic;
 export default ReactNativeBlobUtil;
-import { filedescriptor } from './types';
+import {filedescriptor} from './types';
 import CanceledFetchError from './class/ReactNativeBlobUtilCanceledFetchError'
 
 interface ReactNativeBlobUtilStatic {

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,8 @@
 export const ReactNativeBlobUtil: ReactNativeBlobUtilStatic;
 export type ReactNativeBlobUtil = ReactNativeBlobUtilStatic;
 export default ReactNativeBlobUtil;
-import CanceledFetchError from './class/ReactNativeBlobUtilCancelError'
 import { filedescriptor } from './types';
+import CanceledFetchError from './class/ReactNativeBlobUtilCanceledFetchError'
 
 interface ReactNativeBlobUtilStatic {
     fetch(method: Methods, url: string, headers?: { [key: string]: string }, body?: any

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,8 @@
 export const ReactNativeBlobUtil: ReactNativeBlobUtilStatic;
 export type ReactNativeBlobUtil = ReactNativeBlobUtilStatic;
 export default ReactNativeBlobUtil;
-import {filedescriptor} from './types';
+import CanceledFetchError from './class/ReactNativeBlobUtilCancelError'
+import { filedescriptor } from './types';
 
 interface ReactNativeBlobUtilStatic {
     fetch(method: Methods, url: string, headers?: { [key: string]: string }, body?: any
@@ -29,6 +30,7 @@ interface ReactNativeBlobUtilStatic {
     polyfill: Polyfill;
     // this require external module https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/oboe
     JSONStream: any;
+    CanceledFetchError: CanceledFetchError
 }
 
 export interface Polyfill {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ import ios from './ios';
 import JSONStream from './json-stream';
 import {config, fetch} from './fetch';
 import URIUtil from "./utils/uri";
-import { CanceledFetchError } from ".class/ReactNativeBlobUtilCanceledFetchError";
+import CanceledFetchError from "./class/ReactNativeBlobUtilCanceledFetchError";
 
 const {
     ReactNativeBlobUtilSession,

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ import ios from './ios';
 import JSONStream from './json-stream';
 import {config, fetch} from './fetch';
 import URIUtil from "./utils/uri";
+import { CanceledFetchError } from ".class/ReactNativeBlobUtilCanceledFetchError";
 
 const {
     ReactNativeBlobUtilSession,
@@ -70,5 +71,6 @@ export default {
     wrap,
     polyfill,
     JSONStream,
-    MediaCollection
+    MediaCollection,
+    CanceledFetchError
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-blob-util",
-    "version": "0.17.1",
+    "version": "0.17.2",
     "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
     "main": "index",
     "scripts": {


### PR DESCRIPTION
I need to have a different code path for cancellation than for normal errors. This pr adds support for properly scoping using a custom error instance:

```
    .catch(error => {
      const hasBeenCanceled = error instanceof ReactNativeBlobUtil.CanceledFetchError
```
Since the cancel function rejects the promise, I believe it is better to use a custom error like this to allow people to filter it easily, without resorting to error string comparison.