### PR TITLE
Fix support of FormData in Fetch polyfill on android

### DIFF
--- a/polyfill/Fetch.js
+++ b/polyfill/Fetch.js
@@ -40,7 +40,10 @@ class ReactNativeBlobUtilFetchPolyfill {
                     log.verbose('convert FormData to blob body');
                     promise = Blob.build(body).then((b) => {
                         blobCache = b;
-                        options.headers['Content-Type'] = 'multipart/form-data;boundary=' + b.multipartBoundary;
+
+                        const contentType = 'multipart/form-data;boundary=' + b.multipartBoundary
+                        options.headers['Content-Type'] = contentType;
+                        options.headers['content-type'] = contentType;
                         return Promise.resolve(URIUtil.wrap(b._ref));
                     });
                 }


### PR DESCRIPTION
headers['content-type'] is required because in `ReactNativeBlobUtilReq.java` content type is picked from lower case version