### PR TITLE
Null check HashMap's get result in ReactNativeBlobUtilReq instead of checking for key first, to prevent potential async issues

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
@@ -155,8 +155,8 @@ public class ReactNativeBlobUtilReq extends BroadcastReceiver implements Runnabl
     }
 
     public static void cancelTask(String taskId) {
-        if (taskTable.containsKey(taskId)) {
-            Call call = taskTable.get(taskId);
+        Call call = taskTable.get(taskId);
+        if (call != null) {
             call.cancel();
             taskTable.remove(taskId);
         }


### PR DESCRIPTION
Submitting this as a potential fix for #214 