### PR TITLE
Include failure reason in error from writeFile on iOS

### DIFF
--- a/ios/ReactNativeBlobUtilFS.mm
+++ b/ios/ReactNativeBlobUtilFS.mm
@@ -411,9 +411,9 @@ NSMutableDictionary *fileStreams = nil;
             [fileHandle closeFile];
         }
         else {
-            if (![content writeToFile:path atomically:YES]) {
+            if (![content writeToFile:path options:NSDataWritingAtomic error:&err]) {
                 fm = nil;
-                return reject(@"EUNSPECIFIED", [NSString stringWithFormat:@"File '%@' could not be written.", path], nil);
+                return reject(@"EUNSPECIFIED", [NSString stringWithFormat:@"File '%@' could not be written; error: %@", path, [err description]], err);
             }
         }
         fm = nil;


### PR DESCRIPTION
The current implementation simply returns "file could not be written" if `writeFile` (or, more specifically, `NSData`'s `writeToFile`) fails on iOS. This includes the failure reason from `NSData`, useful for debugging failures.