### PR TITLE
Support Visual Studio 2022

### DIFF
--- a/windows/ReactNativeBlobUtil/ReactNativeBlobUtil.vcxproj
+++ b/windows/ReactNativeBlobUtil/ReactNativeBlobUtil.vcxproj
@@ -60,6 +60,7 @@
     <PlatformToolset>v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>


### PR DESCRIPTION
In VS2022 the build is defaulting to the 2017 build tools, it should default to 2019 build tools