### PR TITLE
Android - Fix failed to build unique file crash

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilMediaCollection.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilMediaCollection.java
@@ -95,8 +95,12 @@ public class ReactNativeBlobUtilMediaCollection {
 
             Uri mediauri = getMediaUri(mt);
 
-            // Keeps a handle to the new file's URI in case we need to modify it later.
-            return resolver.insert(mediauri, fileDetails);
+            try {
+                // Keeps a handle to the new file's URI in case we need to modify it later.
+                return resolver.insert(mediauri, fileDetails);
+            } catch (Exception e) {
+                return null;
+            }
         } else {
             File f = new File(relativePath + file.getFullPath());
             if (true) {


### PR DESCRIPTION
### Description
On Android, copying files to a media store (`copyToMediaStore`) with the same name more than 32 times will crash the app. I'm not sure if the number is vary depends on the device, but on the 33rd time, the app crashed.

<img width="300" alt="image" src="https://github.com/RonRadtke/react-native-blob-util/assets/50919443/6e668b68-0ce1-484d-9736-96dba36f7d68">

The error itself comes from this line of code.
https://github.com/RonRadtke/react-native-blob-util/blob/10401743630359a88ac1c551e948091c09615100/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilMediaCollection.java#L98-L99

This PR wraps it with a `try-catch`. Now, a promise rejection warning will show instead of an error. It would be the developer's responsibility to handle the rejection.