### PR TITLE
refactor(ios): re-align some autosynthesized properties

### DIFF
--- a/ios/ReactNativeBlobUtilProgress.h
+++ b/ios/ReactNativeBlobUtilProgress.h
@@ -17,13 +17,6 @@ typedef NS_ENUM(NSUInteger, ProgressType) {
 };
 
 @interface ReactNativeBlobUtilProgress : NSObject
-{
-    NSNumber * count;
-    NSNumber * interval;
-    ProgressType type;
-    BOOL enable;
-    
-}
 
 @property (nonatomic) NSNumber * count;
 @property (nonatomic) NSNumber * interval;


### PR DESCRIPTION
When building, we get the following warnings regarding the properties of `ReactNativeBlobUtilProgress`:

    Autosynthesized property 'count' will use synthesized instance variable '_count', not existing instance variable 'count'
    Autosynthesized property 'enable' will use synthesized instance variable '_enable', not existing instance variable 'enable'
    Autosynthesized property 'interval' will use synthesized instance variable '_interval', not existing instance variable 'interval'
    Autosynthesized property 'type' will use synthesized instance variable '_type', not existing instance variable 'type'

As all access is via these synthesized properties, the declared instance variables can be removed.