### PR TITLE
Fix import declaration of `mediacollection.js`

### DIFF
--- a/mediacollection.js
+++ b/mediacollection.js
@@ -1,4 +1,4 @@
-import type {ReactNativeBlobUtilNative, filedescriptor} from "types";
+import type {ReactNativeBlobUtilNative, filedescriptor} from "./types";
 import ReactNativeBlobUtil from "./codegenSpecs/NativeBlobUtils";
 
 function createMediafile(fd: filedescriptor, mediatype: string): Promise {


### PR DESCRIPTION
`types` is within this project and should use [relative import](https://www.typescriptlang.org/docs/handbook/module-resolution.html#relative-vs-non-relative-module-imports).