### PR TITLE
fix: reading file from assets

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
@@ -257,9 +257,9 @@ class ReactNativeBlobUtilFS {
             if (resolved != null && resolved.startsWith(ReactNativeBlobUtilConst.FILE_PREFIX_BUNDLE_ASSET)) {
                 String assetName = path.replace(ReactNativeBlobUtilConst.FILE_PREFIX_BUNDLE_ASSET, "");
                 // This fails should an asset file be >2GB
-                length = (int) ReactNativeBlobUtilImpl.RCTContext.getAssets().openFd(assetName).getLength();
-                bytes = new byte[length];
                 InputStream in = ReactNativeBlobUtilImpl.RCTContext.getAssets().open(assetName);
+                length = in.available();
+                bytes = new byte[length];
                 bytesRead = in.read(bytes, 0, length);
                 in.close();
             }


### PR DESCRIPTION
There is no need to call `getAssets().openFd` to get the file length, It is also causing strange error such as `This file can not be opened as a file descriptor; it is probably compressed` when loading a file from assets on android.