### PR TITLE
add missing listener methods (new architecture)

### DIFF
--- a/android/src/newarch/java/com/ReactNativeBlobUtil/ReactNativeBlobUtil.java
+++ b/android/src/newarch/java/com/ReactNativeBlobUtil/ReactNativeBlobUtil.java
@@ -34,7 +34,7 @@ public class ReactNativeBlobUtil extends NativeBlobUtilsSpec {
     }
 
     @ReactMethod
-    public void removeListeners(Integer count) {
+    public void removeListeners(double count) {
 
     }
 

--- a/codegenSpecs/NativeBlobUtils.js
+++ b/codegenSpecs/NativeBlobUtils.js
@@ -75,6 +75,10 @@ export interface Spec extends TurboModule {
     +getSDCardApplicationDir: () => Promise<string>;
     +scanFile: (pairs: Array<any>, callback: (value: Array<any>) => void) => void;
     +writeToMediaFile: (fileUri: string, path: string, transformFile: boolean) => Promise<string>;
+
+    // RCTEventEmitter
+    +addListener: (eventName: string) => void;
+    +removeListeners: (count: number) => void;
   }
 
   export default (TurboModuleRegistry.get<Spec>('ReactNativeBlobUtil'): ?Spec);


### PR DESCRIPTION
Methods `addListener` and `removeListeners` were missing from the codegen spec. Without them, events emitted from native code do not get sent to JS, and warnings are logged complaining about the missing methods.

Fixes: https://github.com/RonRadtke/react-native-blob-util/issues/283

 Possibly also fixes:
  https://github.com/RonRadtke/react-native-blob-util/issues/274
  https://github.com/RonRadtke/react-native-blob-util/issues/292