### PR TITLE
add missing listener methods for windows

### DIFF
--- a/windows/ReactNativeBlobUtil/ReactNativeBlobUtil.cpp
+++ b/windows/ReactNativeBlobUtil/ReactNativeBlobUtil.cpp
@@ -1526,6 +1526,14 @@ void ReactNativeBlobUtil::splitPath(const std::wstring& fullPath, winrt::hstring
 	fileName = path.has_filename() ? winrt::to_hstring(path.filename().c_str()) : L"";
 }
 
+void ReactNativeBlobUtil::addListener(std::string eventName) noexcept
+{
+}
+
+void ReactNativeBlobUtil::removeListeners(double count) noexcept
+{
+}
+
 winrt::Windows::Foundation::IAsyncAction ReactNativeBlobUtil::ProcessRequestAsync(
 	const std::string& taskId,
 	const winrt::Windows::Web::Http::Filters::HttpBaseProtocolFilter& filter,

--- a/windows/ReactNativeBlobUtil/ReactNativeBlobUtil.h
+++ b/windows/ReactNativeBlobUtil/ReactNativeBlobUtil.h
@@ -320,6 +320,19 @@ public:
 		std::string streamId,
 		std::function<void(std::string)> callback) noexcept;
 
+	// addListener
+	REACT_METHOD(addListener);
+	void addListener(
+		std::string eventName
+	) noexcept;
+
+	// removeListeners
+	REACT_METHOD(removeListeners);
+	void removeListeners(
+		double count
+	) noexcept;
+
+
 	// Helper methods
 private:
 	


### PR DESCRIPTION
Method `addListener` and `removeListeners` were missing for windows implementation.