### PR TITLE
Fix for missing symbol BuildConfig

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ if (isNewArchitectureEnabled()) {
 android {
     def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-        namespace "com.ronradtke.rnblobutil"
+        namespace "com.ReactNativeBlobUtil"
     }
     compileSdkVersion safeExtGet('compileSdkVersion', 30)
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,6 +47,9 @@ android {
     def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
         namespace "com.ReactNativeBlobUtil"
+        buildFeatures {
+            buildConfig true
+        }
     }
     compileSdkVersion safeExtGet('compileSdkVersion', 30)
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')


### PR DESCRIPTION
Alternatively the package names could be changed in the java files to match the current namespace.

Fixes #315