### PR TITLE
Fix deprecated iOS API stringByAddingPercentEscapesUsingEncoding:

### DIFF
--- a/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.mm
+++ b/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.mm
@@ -788,7 +788,7 @@ RCT_EXPORT_METHOD(presentOptionsMenu:(NSString*)uri scheme:(NSString *)scheme re
                    resolve:(RCTPromiseResolveBlock)resolve
                     reject:(RCTPromiseRejectBlock)reject
 {
-    NSString * utf8uri = [uri stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString * utf8uri = [uri stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
     NSURL * url = [[NSURL alloc] initWithString:utf8uri];
     // NSURL * url = [[NSURL alloc] initWithString:uri];
     documentController = [UIDocumentInteractionController interactionControllerWithURL:url];
@@ -818,7 +818,7 @@ RCT_EXPORT_METHOD(presentOpenInMenu:(NSString*)uri scheme:(NSString *)scheme res
                   resolve:(RCTPromiseResolveBlock)resolve
                    reject:(RCTPromiseRejectBlock)reject
 {
-    NSString * utf8uri = [uri stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString * utf8uri = [uri stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
     NSURL * url = [[NSURL alloc] initWithString:utf8uri];
     documentController = [UIDocumentInteractionController interactionControllerWithURL:url];
     UIViewController *rootCtrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
@@ -848,7 +848,7 @@ RCT_EXPORT_METHOD(presentPreview:(NSString*)uri scheme:(NSString *)scheme resolv
                resolve:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject
 {
-    NSString * utf8uri = [uri stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString * utf8uri = [uri stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
     NSURL * url = [[NSURL alloc] initWithString:utf8uri];
     // NSURL * url = [[NSURL alloc] initWithString:uri];
     documentController = [UIDocumentInteractionController interactionControllerWithURL:url];


### PR DESCRIPTION
[stringByAddingPercentEscapesUsingEncoding:](https://developer.apple.com/documentation/foundation/nsstring/1415058-stringbyaddingpercentescapesusin) was deprecated in iOS 9.

Using the recommended replacement instead.