### PR TITLE
Use content resolver for content uri on android

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilStream.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilStream.java
@@ -274,20 +274,4 @@ public class ReactNativeBlobUtilStream {
         eventData.putString("streamId", streamName);
         this.emitter.emit(EVENT_FILESYSTEM, eventData);
     }
-
-    /**
-     * Get input stream of the given path, when the path is a string starts with bundle-assets://
-     * the stream is created by Assets Manager, otherwise use FileInputStream.
-     *
-     * @param path The file to open stream
-     * @return InputStream instance
-     * @throws IOException If the given file does not exist or is a directory FileInputStream will throw a FileNotFoundException
-     */
-    public static InputStream inputStreamFromPath(String path) throws IOException {
-        if (path.startsWith(ReactNativeBlobUtilConst.FILE_PREFIX_BUNDLE_ASSET)) {
-            return ReactNativeBlobUtilImpl.RCTContext.getAssets().open(path.replace(ReactNativeBlobUtilConst.FILE_PREFIX_BUNDLE_ASSET, ""));
-        }
-        return new FileInputStream(new File(path));
-    }
-
 }


### PR DESCRIPTION
We encountered exceptions trying to copy from `content://` URI on Android. This happens as soon as the file type isn't one of the few types explictly supported by `ReactNativeBlobUtilUtils.normalizePath`. Trying to extend the supported file types looked like a dead-end: when picking a PDF document from the `Files` app using `react-native-document-picker` for example, we get a `content://` URI which can't be accessed as a regular file as far as I can tell.

So, while `ReactNativeBlobUtilUtils.normalizePath` is definitely useful for destination files, trying to use it too much for source path is problematic.

In this pull-request, I am using [Android ContentResolver.openInputStream()](https://developer.android.com/reference/android/content/ContentResolver#openInputStream(android.net.Uri)) to deal with such URI in `cp`, `hash` and `slice`.

Interestingly, [openInputStream was already used](https://github.com/RonRadtke/react-native-blob-util/blob/master/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java#L268-L276) by [readFile](https://github.com/RonRadtke/react-native-blob-util/wiki/File-System-Access-API#readfilepath-encodingpromise) so I didn't need to fix that case.

