### PR TITLE
chore: first pass at adding a privacy manifest

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -6,7 +6,7 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
-			<string></string>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>E174.1</string>

--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string></string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>0A2A.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/ReactNativeBlobUtil.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeBlobUtil.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		A15C30111CD25C330074CB35 /* ReactNativeBlobUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ReactNativeBlobUtil.h; path = ReactNativeBlobUtil/ReactNativeBlobUtil.h; sourceTree = "<group>"; };
 		A19B48231D98100800E6868A /* ReactNativeBlobUtilProgress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactNativeBlobUtilProgress.h; sourceTree = "<group>"; };
 		A1AAE2971D300E3E0051D11C /* ReactNativeBlobUtilReqBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactNativeBlobUtilReqBuilder.h; sourceTree = "<group>"; };
+		CBE41E482BB345A0004922E9 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		E83F89B1EFF498D9833537A4 /* Pods-ReactNativeBlobUtil.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactNativeBlobUtil.debug.xcconfig"; path = "Target Support Files/Pods-ReactNativeBlobUtil/Pods-ReactNativeBlobUtil.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -87,6 +88,7 @@
 		A15C30051CD25C330074CB35 = {
 			isa = PBXGroup;
 			children = (
+				CBE41E482BB345A0004922E9 /* PrivacyInfo.xcprivacy */,
 				11A307F22A06E47400E56674 /* ReactNativeBlobUtil */,
 				11A307F42A06E47500E56674 /* ReactNativeBlobUtilConst.mm */,
 				11A307F32A06E47400E56674 /* ReactNativeBlobUtilFileTransformer.mm */,

--- a/react-native-blob-util.podspec
+++ b/react-native-blob-util.podspec
@@ -13,6 +13,9 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/RonRadtke/react-native-blob-util" }
   s.author       = 'RonRadtke'
   s.source_files = 'ios/**/*.{h,m,mm,swift}'
+  s.resource_bundles = {
+    'ReactNativeBlobUtilPrivacyInfo' => ['ios/PrivacyInfo.xcprivacy'],
+  }
   s.platforms       = { :ios => "11.0" }
   s.framework    = 'AssetsLibrary'
 


### PR DESCRIPTION
Adds a privacy manifest to comply with apples new requirements for apps and sdks:
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api

Attempts to solve: https://github.com/RonRadtke/react-native-blob-util/issues/342

Please let me know if any changes are needed or there is any particular way I should test this!

Tested by linking the package in our repo and generating privacy report, didn't generate errors. 

@RonRadtke

