### PR TITLE
Remove android proguard rules file from build output

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -54,6 +54,7 @@ android/.idea/scopes/scope_settings.xml
 android/.idea/vcs.xml
 android/*.iml
 android/.settings
+android/proguard-rules.pro
 
 # iOS
 ios/*.xcodeproj/xcuserdata


### PR DESCRIPTION
TITC, the redundant `android/proguard-rules.pro` was excluded from the build output.