### PR TITLE
Ensuring ascii file reads do not fall through to else case for UTF-8 reading

### DIFF
--- a/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.mm
+++ b/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.mm
@@ -680,8 +680,7 @@ RCT_EXPORT_METHOD(readFile:(NSString *)path
         }
         if([encoding isEqualToString:@"ascii"]) {
             resolve((NSMutableArray *)content);
-        }
-        if([encoding isEqualToString:@"base64"]) {
+        } else if([encoding isEqualToString:@"base64"]) {
             resolve([content base64EncodedStringWithOptions:0]);
         } else {
             resolve([[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding]);


### PR DESCRIPTION
In my use of `react-native-blob-util` I was reading files with the ascii encoding. When reading I would receive a `unrecognized selector sent to instance` RCTFatal error. The file read was still successful as the ascii encoding resolve function was still run correctly. The issue was the error was thrown when the UTF8 else case was also run. 

I figure each file read only one encoding resolve function should be run dependant on the encoding passed in by the user. The change to an if/else if/else should ensure only one encoder function runs compared to the previous if/if/else. 