### PR TITLE
Fixed integer overflow issue in slice function for android

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilFS.java
@@ -678,7 +678,7 @@ class ReactNativeBlobUtilFS {
      * @param end    End byte offset
      * @param encode NOT IMPLEMENTED
      */
-    static void slice(String path, String dest, int start, int end, String encode, Promise promise) {
+    static void slice(String path, String dest, long start, long end, String encode, Promise promise) {
         try {
             dest = ReactNativeBlobUtilUtils.normalizePath(dest);
 
@@ -696,13 +696,13 @@ class ReactNativeBlobUtilFS {
                 return;
             }
             FileOutputStream out = new FileOutputStream(new File(dest));
-            int skipped = (int) in.skip(start);
+            long skipped = in.skip(start);
             if (skipped != start) {
                 promise.reject("EUNSPECIFIED", "Skipped " + skipped + " instead of the specified " + start + " bytes");
                 return;
             }
             byte[] buffer = new byte[10240];
-            int remain = end - start;
+            int remain = (int) (end - start);
             while (remain > 0) {
                 int read = in.read(buffer, 0, 10240);
                 if (read <= 0) {

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilImpl.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilImpl.java
@@ -294,7 +294,7 @@ class ReactNativeBlobUtilImpl {
         }
     }
 
-    public void slice(String src, String dest, int start, int end, Promise promise) {
+    public void slice(String src, String dest, long start, long end, Promise promise) {
         ReactNativeBlobUtilFS.slice(src, dest, start, end, "", promise);
     }
 

--- a/android/src/newarch/java/com/ReactNativeBlobUtil/ReactNativeBlobUtil.java
+++ b/android/src/newarch/java/com/ReactNativeBlobUtil/ReactNativeBlobUtil.java
@@ -198,7 +198,7 @@ public class ReactNativeBlobUtil extends NativeBlobUtilsSpec {
 
     @Override
     public void slice(String src, String dest, double start, double end, Promise promise) {
-       delegate.slice(src, dest, (int) start, (int) end, promise);
+       delegate.slice(src, dest, (long) start, (long) end, promise);
     }
 
     @Override

--- a/android/src/oldarch/java/com/ReactNativeBlobUtil/ReactNativeBlobUtil.java
+++ b/android/src/oldarch/java/com/ReactNativeBlobUtil/ReactNativeBlobUtil.java
@@ -174,8 +174,8 @@ public class ReactNativeBlobUtil extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void slice(String src, String dest, int start, int end, Promise promise) {
-        delegate.slice(src, dest, start, end, promise);
+    public void slice(String src, String dest, double start, double end, Promise promise) {
+        delegate.slice(src, dest, (long) start, (long) end, promise);
     }
 
     @ReactMethod


### PR DESCRIPTION
I am not a Java developer, but we were experiencing `integer overflow` issues while working with binary files. The issue was in the `slice` function. `Start` and `end` values were declared as `int` instead of `long`. Please review the code as there could be an unnecessary cast or something missed.