### PR TITLE
Fix out of memory issues hashing large files on iOS

### DIFF
--- a/ios/ReactNativeBlobUtilFS.mm
+++ b/ios/ReactNativeBlobUtilFS.mm
@@ -679,31 +679,41 @@ typedef enum {
         return;
     }
 
-    while ((dataChunk = [fileHandle readDataUpToLength:chunkSize error:&error]) && dataChunk.length > 0) {
-        if (error) {
-            return reject(@"EREAD", [NSString stringWithFormat:@"Error reading file '%@'", path], error);
-            break;
-        }
-        
-        switch(hashAlgorithm) {
-            case HashAlgorithmMD5:
-                CC_MD5_Update(&md5Context, [dataChunk bytes], CC_LONG([dataChunk length]));
+    while (true) {
+        @autoreleasepool {
+            dataChunk = [fileHandle readDataUpToLength:chunkSize error:&error];
+
+            if (error) {
+                return reject(@"EREAD", [NSString stringWithFormat:@"Error reading file '%@'", path], error);
                 break;
-            case HashAlgorithmSHA1:
-                CC_SHA1_Update(&sha1Context, [dataChunk bytes], CC_LONG([dataChunk length]));
+            }
+            
+            if (dataChunk == nil || dataChunk.length == 0) {
                 break;
-            case HashAlgorithmSHA224:
-                CC_SHA224_Update(&sha256Context, [dataChunk bytes], CC_LONG([dataChunk length]));
-                break;
-            case HashAlgorithmSHA256:
-                CC_SHA256_Update(&sha256Context, [dataChunk bytes], CC_LONG([dataChunk length]));
-                break;
-            case HashAlgorithmSHA384:
-                CC_SHA384_Update(&sha512Context, [dataChunk bytes], CC_LONG([dataChunk length]));
-                break;
-            case HashAlgorithmSHA512:
-                CC_SHA512_Update(&sha512Context, [dataChunk bytes], CC_LONG([dataChunk length]));
-                break;
+            }
+            
+            switch(hashAlgorithm) {
+                case HashAlgorithmMD5:
+                    CC_MD5_Update(&md5Context, [dataChunk bytes], CC_LONG([dataChunk length]));
+                    break;
+                case HashAlgorithmSHA1:
+                    CC_SHA1_Update(&sha1Context, [dataChunk bytes], CC_LONG([dataChunk length]));
+                    break;
+                case HashAlgorithmSHA224:
+                    CC_SHA224_Update(&sha256Context, [dataChunk bytes], CC_LONG([dataChunk length]));
+                    break;
+                case HashAlgorithmSHA256:
+                    CC_SHA256_Update(&sha256Context, [dataChunk bytes], CC_LONG([dataChunk length]));
+                    break;
+                case HashAlgorithmSHA384:
+                    CC_SHA384_Update(&sha512Context, [dataChunk bytes], CC_LONG([dataChunk length]));
+                    break;
+                case HashAlgorithmSHA512:
+                    CC_SHA512_Update(&sha512Context, [dataChunk bytes], CC_LONG([dataChunk length]));
+                    break;
+            }
+            
+            dataChunk = nil;
         }
     }
 

--- a/ios/ReactNativeBlobUtilFS.mm
+++ b/ios/ReactNativeBlobUtilFS.mm
@@ -679,7 +679,7 @@ typedef enum {
         return;
     }
 
-    while ((dataChunk = [fileHandle readDataUpToLength:chunkSize error:&error])) {
+    while ((dataChunk = [fileHandle readDataUpToLength:chunkSize error:&error]) && dataChunk.length > 0) {
         if (error) {
             return reject(@"EREAD", [NSString stringWithFormat:@"Error reading file '%@'", path], error);
             break;


### PR DESCRIPTION
The hasing functions on android iterate over the files in 1MB chunks when hashing them.  The iOS was using this api, which reads the entire file into memory at once:

```
NSData *content = [[NSFileManager defaultManager] contentsAtPath:path];
```

For large files, this was causing allocations on iOS to fail or causing out of memory issues.  This change reads the files in 1MB chunks on iOS to avoid this situation.