### PR TITLE
Changed slice  method type 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -448,7 +448,7 @@ export interface FS {
 
     dirs: Dirs;
 
-    slice(src: string, dest: string, start: number, end: number): Promise<void>;
+    slice(src: string, dest: string, start: number, end: number): Promise<string>;
 
     asset(path: string): string;
 


### PR DESCRIPTION
I have been using the `fs.slice` method for almost a year now in my app. and the slice method in the `FS` interface was returning `Promise<void>`, which created a small typing issue in the code. This PR changes it from `Promise<void>` to `Promise<string>`. In all my testing, this method never returned `void`, and because JS loads the sliced file to memory, I don't think it will ever return `void` or any other type other than string. That said, it would be best to test a scenario where the device doesn't have required storage to be able to save the slice in a different directory. In that case, it might break. If I can, I'll test it and update this PR. If anyone else wants to try, let me know. 