### PR TITLE
Fix download issue with file size 2GB+

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/Response/ReactNativeBlobUtilFileResp.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/Response/ReactNativeBlobUtilFileResp.java
@@ -72,10 +72,19 @@ public class ReactNativeBlobUtilFileResp extends ResponseBody {
 
     @Override
     public long contentLength() {
-        if (originalBody.contentLength() > Integer.MAX_VALUE) {
+
+        /**
+         * 
+         * Okio buffer issue in current version seems to be fixed in the latest versions
+         * 
+         * limiting this was causing the download progress to stop at 2GB size but files still was downloading
+         * 
+         */
+
+        // if (originalBody.contentLength() > Integer.MAX_VALUE) {
             // This is a workaround for a bug Okio buffer where it can't handle larger than int.
-            return Integer.MAX_VALUE;
-        }
+            // return Integer.MAX_VALUE;
+        // }
         return originalBody.contentLength();
     }
 


### PR DESCRIPTION
Issue #407 

When downloading files larger then 2GB in progress we were getting total size as Int max and it is due to a condition to fix an bug in OKio.
There was a condition added to fix issue with OKio where body content length size grater then int.
this issue seems fixed in current versions of Okio so we removed that condition.