### PR TITLE
 Add targetHostIp option, support concurrent STA in Android

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilConfig.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilConfig.java
@@ -14,6 +14,7 @@ class ReactNativeBlobUtilConfig {
     public ReadableMap addAndroidDownloads;
     public Boolean trusty;
     public Boolean wifiOnly = false;
+    public String targetHostIp;
     public String key;
     public String mime;
     public Boolean auto;
@@ -32,6 +33,7 @@ class ReactNativeBlobUtilConfig {
         this.appendExt = options.hasKey("appendExt") ? options.getString("appendExt") : "";
         this.trusty = options.hasKey("trusty") && options.getBoolean("trusty");
         this.wifiOnly = options.hasKey("wifiOnly") && options.getBoolean("wifiOnly");
+        this.targetHostIp = options.hasKey("targetHostIp") ? options.getString("targetHostIp") : "";
         if (options.hasKey("addAndroidDownloads")) {
             this.addAndroidDownloads = options.getMap("addAndroidDownloads");
         }

--- a/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/ReactNativeBlobUtilReq.java
@@ -419,6 +419,7 @@ public class ReactNativeBlobUtilReq extends BroadcastReceiver implements Runnabl
                         } 
                         
                         // wifiOnly. selects the first interface with wifi transport
+                        // if targetHostIp is available and it matches, this selection will be overriden
                         if (!found) {
                             clientBuilder.proxy(Proxy.NO_PROXY);
                             clientBuilder.socketFactory(network.getSocketFactory());

--- a/index.d.ts
+++ b/index.d.ts
@@ -719,6 +719,11 @@ export interface ReactNativeBlobUtilConfig {
     wifiOnly?: boolean;
 
     /**
+     * Set this property to search for the WiFi interface that uses this targetHostIp
+     */
+    targetHostIp?: string;
+
+    /**
      * Set this property so redirects are not automatically followed.
      */
     followRedirect?: boolean;


### PR DESCRIPTION
Android 12 introduced [WiFi STA/STA concurrency](https://source.android.com/docs/core/connect/wifi-sta-sta-concurrency).

As you can read in the docs, this enables supported devices to connect to more than one WiFi network at the same time. 
For example, when connecting to an IoT device, the Android device will be connected to both main WiFi and IoT WiFi concurrently:

```
The concurrent local-only and internet connection function allows devices to connect to a local-only connection, such as a connection to an IoT device, concurrently with the primary internet-providing network
```

With the current implementation (master), the `wifiOnly` allows you to route the requests via WiFi interface, but in this case we have two WiFi interfaces and any of them can be selected. This could result in a wrong routed request.

This PR adds a new option `targetHostIp` that allows you to select the IP Address of the device that you want to send the request to. 
 
As a reference, other libraries are already implementing this: https://github.com/Rapsssito/react-native-tcp-socket/pull/193
