### PR TITLE
fix(ios): progress interval and count read incorrectly

### DIFF
--- a/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.mm
+++ b/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.mm
@@ -741,10 +741,12 @@ RCT_EXPORT_METHOD(cancelRequest:(NSString *)taskId callback:(RCTResponseSenderBl
 }
 
 #pragma mark - net.enableProgressReport
-RCT_EXPORT_METHOD(enableProgressReport:(NSString *)taskId interval:(nonnull NSNumber*)interval count:(nonnull NSNumber*)count)
+RCT_EXPORT_METHOD(enableProgressReport:(NSString *)taskId interval:(double)interval count:(double)count)
 {
+    NSNumber *intervalNumber = [NSNumber numberWithDouble:interval];
+    NSNumber *countNumber = [NSNumber numberWithInteger:count];
 
-    ReactNativeBlobUtilProgress * cfg = [[ReactNativeBlobUtilProgress alloc] initWithType:Download interval:interval count:count];
+    ReactNativeBlobUtilProgress * cfg = [[ReactNativeBlobUtilProgress alloc] initWithType:Download interval:intervalNumber count:countNumber];
     [[ReactNativeBlobUtilNetwork sharedInstance] enableProgressReport:taskId config:cfg];
 }
 


### PR DESCRIPTION
This PR fixes [433](https://github.com/RonRadtke/react-native-blob-util/issues/433)
On the new arch, the params passed from JS are read as null. This fix works and has been tested, but IDK about the old arch

Anyway, React Native has frozen the old architecture, and newer versions will no longer support it. So, I think it's time to let it go.
And I highly recommend migrating the library to Nitro, it suits this library and allows better patterns and much better typesafety, in addition to supporting only Swift and Kotlin by default, which reduces the complexity a lot.