### PR TITLE
Fix TypeScript definitions to resolve eslint import-x/no-named-as-default error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: MNB <https://github.com/MNBuyskih>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export const ReactNativeBlobUtil: ReactNativeBlobUtilStatic;
-export type ReactNativeBlobUtil = ReactNativeBlobUtilStatic;
+declare const ReactNativeBlobUtil: ReactNativeBlobUtilStatic;
 export default ReactNativeBlobUtil;
+export type ReactNativeBlobUtil = ReactNativeBlobUtilStatic;
 import { filedescriptor } from "./types";
 import CanceledFetchError from "./class/ReactNativeBlobUtilCanceledFetchError";
 
@@ -800,7 +800,7 @@ export interface AddAndroidDownloads {
     /**
      * If true android download manager will try to save the file to the apps Download direcotry
      */
-    storeLocal?: boolean
+    storeLocal?: boolean;
 }
 
 export interface ReactNativeBlobUtilResponseInfo {


### PR DESCRIPTION
Fixes #448

### Problem
The TypeScript type definitions incorrectly declared a named value export `ReactNativeBlobUtil` that doesn't exist in the actual JavaScript implementation. This caused the eslint rule `import-x/no-named-as-default` to trigger when importing the library using the standard default import pattern.

### Changes
- Removed the incorrect named value export: `export const ReactNativeBlobUtil: ReactNativeBlobUtilStatic;`
- Kept the default export: `export default ReactNativeBlobUtil;`
- Kept the type-only export: `export type ReactNativeBlobUtil = ReactNativeBlobUtilStatic;`

### Why This Fixes It
The JavaScript implementation (index.js) only exports a default object containing the library's API. There is no named value export called `ReactNativeBlobUtil`. The TypeScript definitions now correctly reflect the actual implementation.

Type-only exports (`export type`) don't conflict with default exports since TypeScript keeps types and values in separate namespaces, so this maintains full backward compatibility while fixing the linter issue.

### Backward Compatibility
✅ Default import still works: `import ReactNativeBlobUtil from 'react-native-blob-util'`  
✅ Type annotations still work: `const util: ReactNativeBlobUtil`  
✅ Type imports still work: `import type { ReactNativeBlobUtil } from 'react-native-blob-util'`

### Testing
- [x] TypeScript definitions match JavaScript implementation
- [x] No TypeScript errors in index.d.ts
- [x] Resolves `import-x/no-named-as-default` eslint warning