### PR TITLE
Use `proguard-android-optimize.txt` to support AGP 9.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {


### PR DESCRIPTION
This is needed to support AGP 9.x which will be included inside RN 0.87+

The change is backward compatible, and it would be great if you could ship a release of RN with this change @RonRadtke 