### PR TITLE
fix(android): stream full file body, not just first 8 KB segment

### DIFF
--- a/android/src/main/java/com/ReactNativeBlobUtil/Response/ReactNativeBlobUtilFileResp.java
+++ b/android/src/main/java/com/ReactNativeBlobUtil/Response/ReactNativeBlobUtilFileResp.java
@@ -123,6 +123,11 @@ public class ReactNativeBlobUtilFileResp extends ResponseBody {
                 bytesDownloaded += read > 0 ? read : 0;
                 if (read > 0) {
                     ofStream.write(bytes, 0, (int) read);
+                    // Forward bytes into the Okio sink too. Without this the buffer
+                    // stays empty and buffered consumers (byteStream()/source().read())
+                    // hit a false EOF after the first 8 KB segment, so any file larger
+                    // than one segment fails with "Download interrupted." (0.24.10 regression).
+                    sink.write(bytes, 0, (int) read);
                 } else if (contentLength() == -1 && read == -1) {
                     // End marker has been received for chunked download
                     isEndMarkerReceived = true;


### PR DESCRIPTION
## Problem
  On Android, downloading any file **larger than 8 KB** to disk fails with
  `"Download interrupted."` (0.24.10 regression). Files ≤ 8 KB pass.

  ## Root cause
  `ProgressReportingSource.read()` writes each chunk to the destination file via
  `ofStream` but **never forwards the bytes into the Okio `sink`**. Buffered
  consumers (`byteStream()` / `source().read()`) read from that sink, so after the
  first 8 KB segment the buffer is empty and they hit a **false EOF**.

  `isDownloadComplete()` then compares a truncated `bytesDownloaded` (8192) against
  the real `Content-Length` → not equal → `"Download interrupted."`.
  ## Fix
  Forward the chunk into the sink too, so buffered reads advance to the real end of
  stream. One line: 
  
  ```java
  if (read > 0) {
      ofStream.write(bytes, 0, (int) read);
      sink.write(bytes, 0, (int) read); // honor Okio Source contract
  }   
  ```
  
  ## Verified
  Real device: a 284 KB PDF over CloudFront previously aborted at exactly 8192 bytes
  (`tempBytes: 8192`); with the fix it streams the full body and completes.