### PR TITLE
fix(types): allow HEAD in the Methods union

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -625,7 +625,7 @@ export interface AndroidApi {
     getSDCardApplicationDir(): Promise<string>;
 }
 
-type Methods = "POST" | "GET" | "DELETE" | "PUT" | "PATCH" | "post" | "get" | "delete" | "put" | "patch";
+type Methods = "POST" | "GET" | "DELETE" | "PUT" | "PATCH" | "HEAD" | "post" | "get" | "delete" | "put" | "patch" | "head";
 
 /**
  * A declare class inherits Promise, it has extra method like progress, uploadProgress,


### PR DESCRIPTION
### Problem

`fetch('HEAD', url)` is a type error, even though HEAD works fine at runtime.

`Methods` in the hand-written `index.d.ts` lists POST/GET/DELETE/PUT/PATCH (and their lowercase forms) but not HEAD. Both native layers pass the verb straight through, so the capability is already there and only the declaration is missing:

- **iOS** — `ReactNativeBlobUtilReqBuilder.mm` does `[request setHTTPMethod: method]` on every branch.
- **Android** — `ReactNativeBlobUtilReq.java` does `this.method = method.toUpperCase(Locale.ROOT)` and then `builder.method(method, null)`; only `post`/`put`/`patch` are special-cased to attach a request body.

I confirmed HEAD reaches the network correctly against S3/CloudFront before filing this.

### Change

One line — adds `"HEAD"` and `"head"` to the union. Declaration-only, so there is no runtime behaviour change and nothing to test.

### Why we needed it

We use `ReactNativeBlobUtil` as an offline video-download engine and recently added resumable downloads. To resume safely you have to prove the bytes already on disk are still a prefix of the *same* object before appending to them — otherwise a key rewritten in place appends the new object's tail to the old prefix, and the resulting length matches `resumeFrom + Content-Length` **by construction**, so no arithmetic can detect the corruption.

That needs an `ETag` and a `Content-Length` before the transfer starts. We can't read them from the download response, because on iOS with `IOSBackgroundTask: true` the transfer runs on an `NSURLSession` background configuration that reports a status and **no headers at all**. A `HEAD` first is the only place to get them — hence needing the verb to type-check.

### The patch we're carrying meanwhile

We're shipping this as a `patch-package` patch, alongside our existing patch for the Android 8KB-truncation bug (already fixed on `master` by f0da45e9, so not part of this PR):

```diff
diff --git a/node_modules/react-native-blob-util/index.d.ts b/node_modules/react-native-blob-util/index.d.ts
--- a/node_modules/react-native-blob-util/index.d.ts
+++ b/node_modules/react-native-blob-util/index.d.ts
@@ -625,7 +625,7 @@ export interface AndroidApi {
     getSDCardApplicationDir(): Promise<string>;
 }
 
-type Methods = "POST" | "GET" | "DELETE" | "PUT" | "PATCH" | "post" | "get" | "delete" | "put" | "patch";
+type Methods = "POST" | "GET" | "DELETE" | "PUT" | "PATCH" | "HEAD" | "post" | "get" | "delete" | "put" | "patch" | "head";
 
 /**
  * A declare class inherits Promise, it has extra method like progress, uploadProgress,
```

Happy to add OPTIONS in the same union if you'd prefer to cover the remaining safe verbs in one go — I left it out to keep the change to what I could verify end-to-end.
